### PR TITLE
Removed jit around pmap

### DIFF
--- a/evojax/sim_mgr.py
+++ b/evojax/sim_mgr.py
@@ -186,8 +186,8 @@ class SimManager(object):
             step_once_fn=partial(step_once, task=train_vec_task),
             max_steps=train_vec_task.max_steps)
         if self._num_device > 1:
-            self._train_rollout_fn = jax.jit(jax.pmap(
-                self._train_rollout_fn, in_axes=(0, 0, 0, None)))
+            self._train_rollout_fn = jax.pmap(
+                self._train_rollout_fn, in_axes=(0, 0, 0, None))
 
         # Set up validation functions.
         self._valid_reset_fn = valid_vec_task.reset
@@ -196,8 +196,8 @@ class SimManager(object):
             step_once_fn=partial(step_once, task=valid_vec_task),
             max_steps=valid_vec_task.max_steps)
         if self._num_device > 1:
-            self._valid_rollout_fn = jax.jit(jax.pmap(
-                self._valid_rollout_fn, in_axes=(0, 0, 0, None)))
+            self._valid_rollout_fn = jax.pmap(
+                self._valid_rollout_fn, in_axes=(0, 0, 0, None))
 
     def eval_params(self, params: jnp.ndarray, test: bool) -> jnp.ndarray:
         """Evaluate population parameters or test the best parameter.


### PR DESCRIPTION
As stated in the docs, there is no need to jit pmaps: https://jax.readthedocs.io/en/latest/jax-101/06-parallelism.html#pmap-and-jit

Rather than being unnecessary, it actually appears to be problematic:
`UserWarning: The jitted function <unnamed function> includes a pmap. Using jit-of-pmap can lead to inefficient data movement, as the outer jit does not preserve sharded data representations and instead collects input and output arrays onto a single device. Consider removing the outer jit unless you know what you're doing. See [https://github.com/google/jax/issues/2926].`

