### PR TITLE
Evosax - Augmented Random Search

### DIFF
--- a/evojax/algo/__init__.py
+++ b/evojax/algo/__init__.py
@@ -15,6 +15,8 @@
 from .base import NEAlgorithm
 from .cma_wrapper import CMA
 from .pgpe import PGPE
+from .ars import ARS
 
+Strategies = {"CMA": CMA, "PGPE": PGPE, "ARS": ARS}
 
-__all__ = ['NEAlgorithm', 'CMA', 'PGPE']
+__all__ = ["NEAlgorithm", "CMA", "PGPE", "ARS", "Strategies"]

--- a/evojax/algo/ars.py
+++ b/evojax/algo/ars.py
@@ -1,0 +1,105 @@
+import logging
+from typing import Union
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+from evojax.algo.base import NEAlgorithm
+from evojax.util import create_logger
+
+from evosax import Augmented_RS
+
+
+class ARS(NEAlgorithm):
+    """A wrapper around evosax's Augmented Random Search.
+    Implementation: https://github.com/RobertTLange/evosax/blob/main/evosax/strategies/ars.py
+    Reference: Mania et al. (2018) - https://arxiv.org/pdf/1803.07055.pdf
+
+    NOTE: More details on the optimizer configuration can be found here
+    https://github.com/RobertTLange/evosax/blob/main/evosax/utils/optimizer.py
+    """
+
+    def __init__(
+        self,
+        param_size: int,
+        pop_size: int,
+        elite_ratio: float,
+        optimizer: str = "clipup",
+        optimizer_config: dict = {
+            "lrate_init": 0.15,  # Initial learning rate
+            "lrate_decay": 0.999,  # Multiplicative decay factor
+            "lrate_limit": 0.05,  # Smallest possible lrate
+            "max_speed": 0.3,  # Max. clipping velocity
+            "momentum": 0.9,  # Momentum coefficient
+        },
+        init_stdev: float = 0.01,
+        decay_stdev: float = 0.999,
+        limit_stdev: float = 0.001,
+        seed: int = 0,
+        logger: logging.Logger = None,
+    ):
+        """Initialization function.
+
+        Args:
+            param_size - Parameter size.
+            pop_size - Population size.
+            elite_ratio - Population elite fraction used for gradient estimate.
+            optimizer - Optimizer name ("sgd", "adam", "rmsprop", "clipup").
+            optimizer_config - Configuration of optimizer hyperparameters.
+            init_stdev - Initial scale of Gaussian perturbation.
+            decay_stdev - Multiplicative scale decay between tell iterations.
+            limit_stdev - Smallest scale (clipping limit).
+            seed - Random seed for parameters sampling.
+            logger - Logger.
+        """
+
+        if logger is None:
+            self.logger = create_logger(name="ARS")
+        else:
+            self.logger = logger
+
+        self.param_size = param_size
+        self.pop_size = abs(pop_size)
+        self.elite_ratio = elite_ratio
+        self.rand_key = jax.random.PRNGKey(seed=seed)
+
+        # Instantiate evosax's ARS strategy
+        self.es = Augmented_RS(
+            popsize=pop_size,
+            num_dims=param_size,
+            elite_ratio=elite_ratio,
+            opt_name=optimizer,
+        )
+
+        # Set hyperparameters according to provided inputs
+        self.es_params = self.es.default_params
+        for k, v in optimizer_config.items():
+            self.es_params[k] = v
+        self.es_params["sigma_init"] = init_stdev
+        self.es_params["sigma_decay"] = decay_stdev
+        self.es_params["sigma_limit"] = limit_stdev
+
+        # Initialize the evolution strategy state
+        self.rand_key, init_key = jax.random.split(self.rand_key)
+        self.es_state = self.es.initialize(init_key, self.es_params)
+
+    def ask(self) -> jnp.ndarray:
+        self.rand_key, ask_key = jax.random.split(self.rand_key)
+        self.params, self.es_state = self.es.ask(
+            ask_key, self.es_state, self.es_params
+        )
+        return self.params
+
+    def tell(self, fitness: Union[np.ndarray, jnp.ndarray]) -> None:
+        self.es_state = self.es.tell(
+            self.params, fitness, self.es_state, self.es_params
+        )
+
+    @property
+    def best_params(self) -> jnp.ndarray:
+        return jnp.array(self.es_state["best_member"], copy=True)
+
+    @best_params.setter
+    def best_params(self, params: Union[np.ndarray, jnp.ndarray]) -> None:
+        self.es_state["best_member"] = jnp.array(params, copy=True)
+        self.es_state["m"] = jnp.array(params, copy=True)

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,9 @@
 from setuptools import find_packages, setup
 
 _dct = {}
-with open('evojax/version.py') as f:
+with open("evojax/version.py") as f:
     exec(f.read(), _dct)
-__version__ = _dct['__version__']
+__version__ = _dct["__version__"]
 
 JAX_URL = "https://storage.googleapis.com/jax-releases/jax_releases.html"
 
@@ -34,7 +34,9 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/google/evojax",
     license="Apache 2.0",
-    packages=[package for package in find_packages() if package.startswith("evojax")],
+    packages=[
+        package for package in find_packages() if package.startswith("evojax")
+    ],
     zip_safe=False,
     install_requires=[
         "flax",
@@ -42,6 +44,7 @@ setup(
         "jaxlib>=0.1.65",
         "Pillow",
         "cma",
+        "evosax",
     ],
     dependency_links=[JAX_URL],
     python_requires=">=3.6",


### PR DESCRIPTION
Hi there 🤗 - I am opening a first PR, which adds Augmented Random Search (Mania et al., 2018) to `evojax`. The implementation wraps `evosax`'s.

- Reference: [Mania et al. (2018)](https://arxiv.org/pdf/1803.07055.pdf)
- `evosax` Source Code: https://github.com/RobertTLange/evosax/blob/main/evosax/strategies/ars.py

There are a couple general considerations: 
- `evosax` strategies by default minimize the objective, while all `evojax` tasks maximize. Hence, the `FitnessShaper` has to transform the "raw" fitness.
- In order to easier access the individual strategies, I added a `Strategies` dictionary. This comes in handy when trying to benchmark multiple strategies.
- `evosax` is now a required dependency, which in turn requires newer versions of  jax and jaxlib. I am not sure if this breaks anything. So far when running the benchmarks it did not.

I have also created a [mini-repository for running the benchmarks, storing logs and configuration files](https://github.com/RobertTLange/evojax-benchmarks). Maybe this can be of general interest? I am planning to add a [`mle-hyperopt`](https://github.com/mle-infrastructure/mle-hyperopt) parameter search pipeline. You can find the ARS logs [here](https://github.com/RobertTLange/evojax-benchmarks/tree/main/log/ARS) and this is the benchmarking summary for ARS:

|   | Benchmarks | Parameters | Results |
|---|---|---|---|
CartPole (easy) | 	900 (max_iter=1000)|[Link](https://github.com/RobertTLange/evojax-benchmarks/blob/main/configs/ars/cartpole_easy.yaml)| 902.107 |
CartPole (hard)	| 600 (max_iter=1000)|[Link](https://github.com/RobertTLange/evojax-benchmarks/blob/main/configs/ars/cartpole_hard.yaml)| 666.6442 |
Waterworld	| 6 (max_iter=500)	 |[Link](https://github.com/RobertTLange/evojax-benchmarks/blob/main/configs/ars/waterworld.yaml)| 6.1300 |
Waterworld (MA)	| 2 (max_iter=2000)	| [Link](https://github.com/RobertTLange/evojax-benchmarks/blob/main/configs/ars/waterworld_ma.yaml)| 1.4831 |
Brax Ant |	3000 (max_iter=300) |[Link](https://github.com/RobertTLange/evojax-benchmarks/blob/main/configs/ars/brax_ant.yaml)| 3298.9746 |
MNIST	| 90.0 (max_iter=2000)	| [Link](https://github.com/RobertTLange/evojax-benchmarks/blob/main/configs/ars/mnist.yaml)| 0.9610 |

**Update**: I added hyperparameter search utilities and coarsely grid searched the initiatl learning rate and standard deviation. Here are some results for the cartpole and mnist taks:

| Cartpole-Easy  | Cartpole-Hard | MNIST |
|---|---|---|
![](https://github.com/RobertTLange/evojax-benchmarks/blob/main/figures/ARS/cartpole_easy.png?raw=true) | ![](https://github.com/RobertTLange/evojax-benchmarks/blob/main/figures/ARS/cartpole_hard.png?raw=true) | ![](https://github.com/RobertTLange/evojax-benchmarks/blob/main/figures/ARS/mnist.png?raw=true) |