### PR TITLE
Rename `evosax` strategies after v0.0.4 release

### DIFF
--- a/evojax/algo/ars.py
+++ b/evojax/algo/ars.py
@@ -58,15 +58,18 @@ class ARS(NEAlgorithm):
         # Delayed importing of evosax
 
         if sys.version_info.minor < 7:
-            print('evosax, which is needed by Augmented Random Search, requires python>=3.7')
-            print('  please consider upgrading your Python version.')
+            print(
+                "evosax, which is needed by Augmented Random Search, requires"
+                " python>=3.7"
+            )
+            print("  please consider upgrading your Python version.")
             sys.exit(1)
 
         try:
-            from evosax import Augmented_RS, FitnessShaper
+            import evosax
         except ModuleNotFoundError:
-            print('You need to install evosax for its Augmented Random Search:')
-            print('  pip install evosax')
+            print("You need to install evosax for its Augmented Random Search:")
+            print("  pip install evosax")
             sys.exit(1)
 
         # Set up object variables.
@@ -82,7 +85,7 @@ class ARS(NEAlgorithm):
         self.rand_key = jax.random.PRNGKey(seed=seed)
 
         # Instantiate evosax's ARS strategy
-        self.es = Augmented_RS(
+        self.es = evosax.ARS(
             popsize=pop_size,
             num_dims=param_size,
             elite_ratio=elite_ratio,
@@ -105,7 +108,7 @@ class ARS(NEAlgorithm):
 
         # By default evojax assumes maximization of fitness score!
         # Evosax, on the other hand, minimizes!
-        self.fit_shaper = FitnessShaper(w_decay=w_decay, maximize=True)
+        self.fit_shaper = evosax.FitnessShaper(w_decay=w_decay, maximize=True)
 
     def ask(self) -> jnp.ndarray:
         self.rand_key, ask_key = jax.random.split(self.rand_key)

--- a/evojax/algo/open_es.py
+++ b/evojax/algo/open_es.py
@@ -59,12 +59,12 @@ class OpenES(NEAlgorithm):
         # Delayed importing of evosax
 
         if sys.version_info.minor < 7:
-            print('evosax, which is needed byOpenES, requires python>=3.7')
-            print('  please consider upgrading your Python version.')
+            print("evosax, which is needed byOpenES, requires python>=3.7")
+            print("  please consider upgrading your Python version.")
             sys.exit(1)
 
         try:
-            from evosax import Open_ES, FitnessShaper
+            import evosax
         except ModuleNotFoundError:
             print("You need to install evosax for its OpenES implementation:")
             print("  pip install evosax")
@@ -80,7 +80,7 @@ class OpenES(NEAlgorithm):
         self.rand_key = jax.random.PRNGKey(seed=seed)
 
         # Instantiate evosax's Open ES strategy
-        self.es = Open_ES(
+        self.es = evosax.OpenES(
             popsize=pop_size,
             num_dims=param_size,
             opt_name=optimizer,
@@ -102,7 +102,7 @@ class OpenES(NEAlgorithm):
 
         # By default evojax assumes maximization of fitness score!
         # Evosax, on the other hand, minimizes!
-        self.fit_shaper = FitnessShaper(
+        self.fit_shaper = evosax.FitnessShaper(
             centered_rank=True, z_score=True, w_decay=w_decay, maximize=True
         )
 


### PR DESCRIPTION
I just [released v0.0.4](https://github.com/RobertTLange/evosax/releases/tag/v0.0.4) of `evosax` and decided to rename a couple of strategies (e.g. `Augmented_RS` -> `ARS`). This PR updates the `evojax` wrappers. Please excuse the inconvenience. I don't expect any further of such frontend changes.