### PR TITLE
Evosax - Sep-CMA-ES

### DIFF
--- a/evojax/algo/__init__.py
+++ b/evojax/algo/__init__.py
@@ -18,6 +18,7 @@ from .pgpe import PGPE
 from .ars import ARS
 from .simple_ga import SimpleGA
 from .open_es import OpenES
+from .sep_cma_es import Sep_CMA_ES
 
 Strategies = {
     "CMA": CMA,
@@ -25,6 +26,7 @@ Strategies = {
     "SimpleGA": SimpleGA,
     "ARS": ARS,
     "OpenES": OpenES,
+    "Sep_CMA_ES": Sep_CMA_ES,
 }
 
 __all__ = [
@@ -34,5 +36,6 @@ __all__ = [
     "ARS",
     "SimpleGA",
     "OpenES",
+    "Sep_CMA_ES",
     "Strategies",
 ]

--- a/evojax/algo/ars.py
+++ b/evojax/algo/ars.py
@@ -58,15 +58,18 @@ class ARS(NEAlgorithm):
         # Delayed importing of evosax
 
         if sys.version_info.minor < 7:
-            print('evosax, which is needed by Augmented Random Search, requires python>=3.7')
-            print('  please consider upgrading your Python version.')
+            print(
+                "evosax, which is needed by Augmented Random Search, requires"
+                " python>=3.7"
+            )
+            print("  please consider upgrading your Python version.")
             sys.exit(1)
 
         try:
-            from evosax import Augmented_RS, FitnessShaper
+            import evosax
         except ModuleNotFoundError:
-            print('You need to install evosax for its Augmented Random Search:')
-            print('  pip install evosax')
+            print("You need to install evosax for its Augmented Random Search:")
+            print("  pip install evosax")
             sys.exit(1)
 
         # Set up object variables.
@@ -82,7 +85,7 @@ class ARS(NEAlgorithm):
         self.rand_key = jax.random.PRNGKey(seed=seed)
 
         # Instantiate evosax's ARS strategy
-        self.es = Augmented_RS(
+        self.es = evosax.ARS(
             popsize=pop_size,
             num_dims=param_size,
             elite_ratio=elite_ratio,
@@ -105,7 +108,7 @@ class ARS(NEAlgorithm):
 
         # By default evojax assumes maximization of fitness score!
         # Evosax, on the other hand, minimizes!
-        self.fit_shaper = FitnessShaper(w_decay=w_decay, maximize=True)
+        self.fit_shaper = evosax.FitnessShaper(w_decay=w_decay, maximize=True)
 
     def ask(self) -> jnp.ndarray:
         self.rand_key, ask_key = jax.random.split(self.rand_key)

--- a/evojax/algo/open_es.py
+++ b/evojax/algo/open_es.py
@@ -59,12 +59,12 @@ class OpenES(NEAlgorithm):
         # Delayed importing of evosax
 
         if sys.version_info.minor < 7:
-            print('evosax, which is needed byOpenES, requires python>=3.7')
-            print('  please consider upgrading your Python version.')
+            print("evosax, which is needed byOpenES, requires python>=3.7")
+            print("  please consider upgrading your Python version.")
             sys.exit(1)
 
         try:
-            from evosax import Open_ES, FitnessShaper
+            import evosax
         except ModuleNotFoundError:
             print("You need to install evosax for its OpenES implementation:")
             print("  pip install evosax")
@@ -80,7 +80,7 @@ class OpenES(NEAlgorithm):
         self.rand_key = jax.random.PRNGKey(seed=seed)
 
         # Instantiate evosax's Open ES strategy
-        self.es = Open_ES(
+        self.es = evosax.OpenES(
             popsize=pop_size,
             num_dims=param_size,
             opt_name=optimizer,
@@ -102,7 +102,7 @@ class OpenES(NEAlgorithm):
 
         # By default evojax assumes maximization of fitness score!
         # Evosax, on the other hand, minimizes!
-        self.fit_shaper = FitnessShaper(
+        self.fit_shaper = evosax.FitnessShaper(
             centered_rank=True, z_score=True, w_decay=w_decay, maximize=True
         )
 

--- a/evojax/algo/sep_cma_es.py
+++ b/evojax/algo/sep_cma_es.py
@@ -1,0 +1,107 @@
+import sys
+
+import logging
+from typing import Union
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+from evojax.algo.base import NEAlgorithm
+from evojax.util import create_logger
+
+
+class Sep_CMA_ES(NEAlgorithm):
+    """A wrapper around evosax's Sep-CMA-ES.
+    Implementation: https://github.com/RobertTLange/evosax/blob/main/evosax/strategies/sep_cma_es.py
+    Reference: Ros & Hansen (2008) - https://hal.inria.fr/inria-00287367/document
+    """
+
+    def __init__(
+        self,
+        param_size: int,
+        pop_size: int,
+        elite_ratio: float = 0.5,
+        init_stdev: float = 0.1,
+        w_decay: float = 0.0,
+        seed: int = 0,
+        logger: logging.Logger = None,
+    ):
+        """Initialization function.
+
+        Args:
+            param_size - Parameter size.
+            pop_size - Population size.
+            elite_ratio - Population elite fraction used for gradient estimate.
+            init_stdev - Initial scale of istropic part of covariance.
+            w_decay - L2 weight regularization coefficient.
+            seed - Random seed for parameters sampling.
+            logger - Logger.
+        """
+
+        # Delayed importing of evosax
+
+        if sys.version_info.minor < 7:
+            print("evosax, which is needed by Sep-CMA-ES, requires python>=3.7")
+            print("  please consider upgrading your Python version.")
+            sys.exit(1)
+
+        try:
+            import evosax
+        except ModuleNotFoundError:
+            print("You need to install evosax for its Sep-CMA-ES:")
+            print("  pip install evosax")
+            sys.exit(1)
+
+        # Set up object variables.
+
+        if logger is None:
+            self.logger = create_logger(name="Sep_CMA_ES")
+        else:
+            self.logger = logger
+
+        self.param_size = param_size
+        self.pop_size = abs(pop_size)
+        self.elite_ratio = elite_ratio
+        self.rand_key = jax.random.PRNGKey(seed=seed)
+
+        # Instantiate evosax's ARS strategy
+        self.es = evosax.Sep_CMA_ES(
+            popsize=pop_size,
+            num_dims=param_size,
+            elite_ratio=elite_ratio,
+        )
+
+        # Set hyperparameters according to provided inputs
+        self.es_params = self.es.default_params
+        self.es_params["sigma_init"] = init_stdev
+
+        # Initialize the evolution strategy state
+        self.rand_key, init_key = jax.random.split(self.rand_key)
+        self.es_state = self.es.initialize(init_key, self.es_params)
+
+        # By default evojax assumes maximization of fitness score!
+        # Evosax, on the other hand, minimizes!
+        self.fit_shaper = evosax.FitnessShaper(w_decay=w_decay, maximize=True)
+
+    def ask(self) -> jnp.ndarray:
+        self.rand_key, ask_key = jax.random.split(self.rand_key)
+        self.params, self.es_state = self.es.ask(
+            ask_key, self.es_state, self.es_params
+        )
+        return self.params
+
+    def tell(self, fitness: Union[np.ndarray, jnp.ndarray]) -> None:
+        # Reshape fitness to conform with evosax minimization
+        fit_re = self.fit_shaper.apply(self.params, fitness)
+        self.es_state = self.es.tell(
+            self.params, fit_re, self.es_state, self.es_params
+        )
+
+    @property
+    def best_params(self) -> jnp.ndarray:
+        return jnp.array(self.es_state["mean"], copy=True)
+
+    @best_params.setter
+    def best_params(self, params: Union[np.ndarray, jnp.ndarray]) -> None:
+        self.es_state["best_member"] = jnp.array(params, copy=True)
+        self.es_state["mean"] = jnp.array(params, copy=True)

--- a/scripts/benchmarks/Readme.md
+++ b/scripts/benchmarks/Readme.md
@@ -59,6 +59,19 @@ This will sequentially execute 25 ARS-MNIST evolution runs for a grid of differe
 
 ## Benchmark Results
 
+### Sep-CMA-ES
+
+
+|   | Benchmarks | Parameters | Results (Avg) |
+|---|---|---|---|
+CartPole (easy) | 	900 (max_iter=1000)|[Link](configs/Sep_CMA_ES/cartpole_easy.yaml)| 924.3028 |
+CartPole (hard)	| 600 (max_iter=1000)|[Link](configs/Sep_CMA_ES/cartpole_hard.yaml)| 626.9728 |
+MNIST	| 90.0 (max_iter=2000)	| [Link](configs/Sep_CMA_ES/mnist.yaml)| 0.9545 |
+Brax Ant |	3000 (max_iter=1200) |[Link](configs/Sep_CMA_ES/brax_ant.yaml)| 3980.9194 |
+Waterworld	| 6 (max_iter=500)	 | [Link](configs/Sep_CMA_ES/waterworld.yaml)| 9.9000 |
+Waterworld (MA)	| 2 (max_iter=2000)	| [Link](configs/Sep_CMA_ES/waterworld_ma.yaml) | 1.1875 |
+
+
 ### PGPE
 
 

--- a/scripts/benchmarks/configs/Sep_CMA_ES/brax_ant.yaml
+++ b/scripts/benchmarks/configs/Sep_CMA_ES/brax_ant.yaml
@@ -1,0 +1,16 @@
+es_name: "Sep_CMA_ES"
+problem_type: "brax"
+env_name: "ant"
+normalize: true
+es_config:
+  pop_size: 1024
+  elite_ratio: 0.5
+  init_stdev: 0.1
+num_tests: 128
+n_repeats: 16
+max_iter: 300
+test_interval: 100
+log_interval: 20
+seed: 42
+gpu_id: [0, 1, 2, 3]
+debug: false

--- a/scripts/benchmarks/configs/Sep_CMA_ES/cartpole_easy.yaml
+++ b/scripts/benchmarks/configs/Sep_CMA_ES/cartpole_easy.yaml
@@ -1,0 +1,16 @@
+es_name: "Sep_CMA_ES"
+problem_type: "cartpole_easy"
+normalize: false
+es_config:
+  pop_size: 100
+  elite_ratio: 0.5
+  init_stdev: 0.15
+hidden_size: 64
+num_tests: 100
+n_repeats: 16
+max_iter: 1000
+test_interval: 100
+log_interval: 50
+seed: 42
+gpu_id: 0
+debug: false

--- a/scripts/benchmarks/configs/Sep_CMA_ES/cartpole_hard.yaml
+++ b/scripts/benchmarks/configs/Sep_CMA_ES/cartpole_hard.yaml
@@ -1,0 +1,16 @@
+es_name: "Sep_CMA_ES"
+problem_type: "cartpole_hard"
+normalize: false
+es_config:
+  pop_size: 100
+  elite_ratio: 0.5
+  init_stdev: 0.15
+hidden_size: 64
+num_tests: 100
+n_repeats: 16
+max_iter: 1000
+test_interval: 100
+log_interval: 50
+seed: 42
+gpu_id: 0
+debug: false

--- a/scripts/benchmarks/configs/Sep_CMA_ES/mnist.yaml
+++ b/scripts/benchmarks/configs/Sep_CMA_ES/mnist.yaml
@@ -1,0 +1,17 @@
+es_name: "Sep_CMA_ES"
+problem_type: "mnist"
+normalize: false
+es_config:
+  pop_size: 100
+  elite_ratio: 0.5
+  init_stdev: 0.065
+hidden_size: 100
+batch_size: 1024
+max_iter: 2000
+test_interval: 500
+log_interval: 100
+num_tests: 1
+n_repeats: 1
+seed: 42
+gpu_id: [0, 1, 2, 3]
+debug: false

--- a/scripts/benchmarks/configs/Sep_CMA_ES/waterworld.yaml
+++ b/scripts/benchmarks/configs/Sep_CMA_ES/waterworld.yaml
@@ -1,0 +1,16 @@
+es_name: "Sep_CMA_ES"
+problem_type: "waterworld"
+normalize: false
+es_config:
+  pop_size: 256
+  elite_ratio: 0.5
+  init_stdev: 0.065
+hidden_size: 100
+num_tests: 100
+n_repeats: 32
+max_iter: 1000
+test_interval: 50
+log_interval: 10
+seed: 42
+gpu_id: [0, 1, 2, 3]
+debug: false

--- a/scripts/benchmarks/configs/Sep_CMA_ES/waterworld_ma.yaml
+++ b/scripts/benchmarks/configs/Sep_CMA_ES/waterworld_ma.yaml
@@ -1,0 +1,16 @@
+es_name: "Sep_CMA_ES"
+problem_type: "waterworld_ma"
+normalize: false
+es_config:
+  pop_size: 16
+  elite_ratio: 0.5
+  init_stdev: 0.065
+hidden_size: 100
+num_tests: 16
+n_repeats: 64
+max_iter: 2000
+test_interval: 100
+log_interval: 10
+seed: 42
+gpu_id: 0
+debug: false


### PR DESCRIPTION
- Reference: [Ros & Hansen (2008)](https://hal.inria.fr/inria-00287367/document)
- `evosax` Source Code: https://github.com/RobertTLange/evosax/blob/main/evosax/strategies/sep_cma_es.py
- This PR adds a CMA-ES version which imposes a diagonal structure for the estimated covariance matrix. Thereby it is a lot more memory efficient as compared to pure CMA-ES, which has do store a (d x d) matrix.
- Benchmarks and hyperparameters:

|   | Benchmarks | Parameters | Results (Avg) |
|---|---|---|---|
CartPole (easy) | 	900 (max_iter=1000)|[Link](https://github.com/google/evojax/blob/main/scripts/benchmarks/configs/Sep_CMA_ES/cartpole_easy.yaml)| 924.3028 |
CartPole (hard)	| 600 (max_iter=1000)|[Link](https://github.com/google/evojax/blob/main/scripts/benchmarks/configs/Sep_CMA_ES/cartpole_hard.yaml)| 626.9728 |
MNIST	| 90.0 (max_iter=2000)	| [Link](https://github.com/google/evojax/blob/main/scripts/benchmarks/configs/Sep_CMA_ES/mnist.yaml)| 0.9545 |
Brax Ant |	3000 (max_iter=300) |[Link](https://github.com/google/evojax/blob/main/scripts/benchmarks/configs/Sep_CMA_ES/brax_ant.yaml)| 3980.9194 |
Waterworld	| 6 (max_iter=500)	 | [Link](https://github.com/google/evojax/blob/main/scripts/benchmarks/configs/Sep_CMA_ES/waterworld.yaml)| 9.9000 |
Waterworld (MA)	| 2 (max_iter=2000)	| [Link](https://github.com/google/evojax/blob/main/scripts/benchmarks/configs/Sep_CMA_ES/waterworld_ma.yaml) | 1.1875 |


**Note**: Linting doesn't pass due to import error for `Open_ES` - see PR #19. This has to be merged first.