### PR TITLE
add map-elites, with a brax ant example

### DIFF
--- a/evojax/algo/__init__.py
+++ b/evojax/algo/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .base import NEAlgorithm
+from .base import QualityDiversityMethod
 from .cma_wrapper import CMA
 from .pgpe import PGPE
 from .ars import ARS
@@ -21,6 +22,7 @@ from .open_es import OpenES
 from .cma_evosax import CMA_ES
 from .sep_cma_es import Sep_CMA_ES
 from .cma_jax import CMA_ES_JAX
+from .map_elites import MAPElites
 
 Strategies = {
     "CMA": CMA,
@@ -30,11 +32,13 @@ Strategies = {
     "OpenES": OpenES,
     "CMA_ES": CMA_ES,
     "Sep_CMA_ES": Sep_CMA_ES,
-    "CMA_ES_JAX": CMA_ES_JAX
+    "CMA_ES_JAX": CMA_ES_JAX,
+    "MAPElites": MAPElites,
 }
 
 __all__ = [
     "NEAlgorithm",
+    "QualityDiversityMethod",
     "CMA",
     "PGPE",
     "ARS",
@@ -43,5 +47,6 @@ __all__ = [
     "CMA_ES",
     "Sep_CMA_ES",
     "CMA_ES_JAX",
+    "MAPElites",
     "Strategies",
 ]

--- a/evojax/algo/base.py
+++ b/evojax/algo/base.py
@@ -14,6 +14,7 @@
 
 from abc import ABC
 from abc import abstractmethod
+from typing import Dict
 from typing import Union
 import numpy as np
 import jax.numpy as jnp
@@ -48,4 +49,16 @@ class NEAlgorithm(ABC):
 
     @best_params.setter
     def best_params(self, params: Union[np.ndarray, jnp.ndarray]) -> None:
+        raise NotImplementedError()
+
+
+class QualityDiversityMethod(NEAlgorithm, ABC):
+    """Quality diversity method."""
+
+    params_lattice: jnp.ndarray
+    fitness_lattice: jnp.ndarray
+    occupancy_lattice: jnp.ndarray
+
+    @abstractmethod
+    def observe_bd(self, bd: Dict[str, jnp.ndarray]) -> None:
         raise NotImplementedError()

--- a/evojax/algo/base.py
+++ b/evojax/algo/base.py
@@ -52,7 +52,7 @@ class NEAlgorithm(ABC):
         raise NotImplementedError()
 
 
-class QualityDiversityMethod(NEAlgorithm, ABC):
+class QualityDiversityMethod(NEAlgorithm):
     """Quality diversity method."""
 
     params_lattice: jnp.ndarray

--- a/evojax/algo/map_elites.py
+++ b/evojax/algo/map_elites.py
@@ -1,0 +1,154 @@
+# Copyright 2022 The EvoJAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation of the MAP-ELITES algorithm in JAX.
+
+Ref: https://arxiv.org/pdf/1504.04909.pdf
+
+In this implementation, we use a modified version iso+line emitter.
+"""
+
+import logging
+import numpy as np
+from typing import Optional
+from typing import Union
+
+import jax
+import jax.numpy as jnp
+
+from evojax.algo.base import QualityDiversityMethod
+from evojax.task.base import TaskState
+from evojax.task.base import BDExtractor
+from evojax.util import create_logger
+
+
+class MAPElites(QualityDiversityMethod):
+    """The MAP-ELITES algorithm."""
+
+    def __init__(self,
+                 pop_size: int,
+                 param_size: int,
+                 bd_extractor: BDExtractor,
+                 init_params: Optional[Union[jnp.ndarray, np.ndarray]] = None,
+                 iso_sigma: float = 0.05,
+                 line_sigma: float = 0.5,
+                 seed: int = 0,
+                 logger: logging.Logger = None):
+        """Initialization function.
+
+        Args:
+            pop_size - Population size.
+            param_size - Parameter size.
+            bd_extractors - A list of behavior descriptor extractors.
+            init_params - Initial parameters, all zeros if not given.
+            iso_sigma - Standard deviation for Gaussian sampling for mutation.
+            line_sigma - Parameter for cross over.
+            seed - Random seed for parameters sampling.
+            logger - Logging utility.
+        """
+
+        if logger is None:
+            self._logger = create_logger(name='MAP_ELITES')
+        else:
+            self._logger = logger
+
+        self.pop_size = abs(pop_size)
+        self.param_size = param_size
+        self.bd_names = [x[0] for x in bd_extractor.bd_spec]
+        self.bd_n_bins = [x[1] for x in bd_extractor.bd_spec]
+        self.params_lattice = jnp.zeros((np.prod(self.bd_n_bins), param_size))
+        self.fitness_lattice = -float('Inf') * jnp.ones(np.prod(self.bd_n_bins))
+        self.occupancy_lattice = jnp.zeros(
+            np.prod(self.bd_n_bins), dtype=jnp.int32)
+        self.population = None
+        self.bin_idx = jnp.zeros(self.pop_size, dtype=jnp.int32)
+        self.key = jax.random.PRNGKey(seed)
+
+        init_param = (
+            jnp.array(init_params)
+            if init_params is not None else jnp.zeros(param_size))
+
+        def sample_parents(key, occupancy, params):
+            new_key, sample_key, mutate_key = jax.random.split(key, 3)
+            parents = jax.lax.cond(
+                occupancy.sum() > 0,
+                lambda: jnp.take(params, axis=0, indices=jax.random.choice(
+                    key=sample_key, a=jnp.arange(occupancy.size), replace=True,
+                    p=occupancy / occupancy.sum(), shape=(2 * self.pop_size,))),
+                lambda: init_param[None, :] + iso_sigma * jax.random.normal(
+                    sample_key, shape=(2 * self.pop_size, self.param_size)),
+            )
+            return new_key, mutate_key, parents.reshape((2, self.pop_size, -1))
+        self._sample_parents = jax.jit(sample_parents)
+
+        def generate_population(parents, key):
+            k1, k2 = jax.random.split(key, 2)
+            return (parents[0] + iso_sigma *
+                    jax.random.normal(key=k1, shape=parents[0].shape) +
+                    # Uniform sampling instead of Gaussian.
+                    jax.random.uniform(
+                        key=k2, minval=0, maxval=line_sigma, shape=()) *
+                    (parents[1] - parents[0]))
+        self._gen_pop = jax.jit(generate_population)
+
+        def get_bin_idx(task_state):
+            bd_idx = [
+                task_state.__dict__[name].astype(int) for name in self.bd_names]
+            return jnp.ravel_multi_index(bd_idx, self.bd_n_bins, mode='clip')
+        self._get_bin_idx = jax.jit(jax.vmap(get_bin_idx))
+
+        def update_fitness_and_param(
+                target_bin, bin_idx,
+                fitness, fitness_lattice, param, param_lattice):
+            best_ix = jnp.where(
+                bin_idx == target_bin, fitness, fitness_lattice.min()).argmax()
+            best_fitness = fitness[best_ix]
+            new_fitness_lattice = jnp.where(
+                best_fitness > fitness_lattice[target_bin],
+                best_fitness, fitness_lattice[target_bin])
+            new_param_lattice = jnp.where(
+                best_fitness > fitness_lattice[target_bin],
+                param[best_ix], param_lattice[target_bin])
+            return new_fitness_lattice, new_param_lattice
+        self._update_lattices = jax.jit(jax.vmap(
+            update_fitness_and_param,
+            in_axes=(0, None, None, None, None, None)))
+
+    def ask(self) -> jnp.ndarray:
+        self.key, mutate_key, parents = self._sample_parents(
+            key=self.key,
+            occupancy=self.occupancy_lattice,
+            params=self.params_lattice)
+        self.population = self._gen_pop(parents, mutate_key)
+        return self.population
+
+    def observe_bd(self, task_state: TaskState) -> None:
+        self.bin_idx = self._get_bin_idx(task_state)
+
+    def tell(self, fitness: Union[np.ndarray, jnp.ndarray]) -> None:
+        unique_bins = jnp.unique(self.bin_idx)
+        fitness_lattice, params_lattice = self._update_lattices(
+            unique_bins, self.bin_idx,
+            fitness, self.fitness_lattice,
+            self.population, self.params_lattice)
+        self.occupancy_lattice = self.occupancy_lattice.at[unique_bins].set(1)
+        self.fitness_lattice = self.fitness_lattice.at[unique_bins].set(
+            fitness_lattice)
+        self.params_lattice = self.params_lattice.at[unique_bins].set(
+            params_lattice)
+
+    @property
+    def best_params(self) -> jnp.ndarray:
+        ix = jnp.argmax(self.fitness_lattice, axis=0)
+        return self.params_lattice[ix]

--- a/evojax/task/base.py
+++ b/evojax/task/base.py
@@ -14,8 +14,14 @@
 
 from abc import ABC
 from abc import abstractmethod
+from typing import Dict
+from typing import List
 from typing import Tuple
+from typing import TypeVar
+import dataclasses
+
 import jax.numpy as jnp
+from flax.struct import dataclass
 
 
 class TaskState(ABC):
@@ -56,5 +62,114 @@ class VectorizedTask(ABC):
             TaskState. Task states.
             jnp.ndarray. Reward.
             jnp.ndarray. Task termination flag: 1 for done, 0 otherwise.
+        """
+        raise NotImplementedError()
+
+
+T = TypeVar('T')
+
+
+class BDExtractor(object):
+    """Behavior descriptor extractor."""
+
+    def __init__(self,
+                 bd_spec: List[Tuple[str, int]],
+                 bd_state_spec: List[Tuple[str, T]],
+                 task_state_def: T):
+        """Initialization of a behavior descriptor extractor.
+
+        Args:
+            bd_spec - A list of behavior descriptors, each of which gives the
+                      name and the number of bins. E.g. [('bd1', 10), ...]
+            bd_state_spec - A list of states that record rollout statistics to
+                            help calculate the behavior descriptors.
+                            E.g. [('bd1_stat1', jnp.int32), ...]
+            task_state_def - The original task definition. BDExtractor extends
+                             that definition to record data in rollouts.
+        """
+        self.bd_spec = bd_spec
+        if bd_state_spec is None:
+            self.bd_state_spec = []
+        else:
+            self.bd_state_spec = bd_state_spec
+        self.extended_task_state = self.get_extended_task_state_def(
+            task_state_def)
+
+    def get_extended_task_state_def(self, task_state_def: T) -> T:
+        """Augment the original task state definition with more entries.
+
+        Args:
+            task_state_def - This should be a flax.struct.dataclass instance.
+        Returns:
+            A flax.struct.dataclass type of class definition with extra entries.
+        """
+        if self.bd_spec is None:
+            return task_state_def
+        else:
+            fields = []
+            # Keep what is in the original task_state.
+            data_fields = task_state_def.__dict__['__annotations__']
+            for name, field in data_fields.items():
+                fields.append((name, field))
+            # Add bd fields.
+            fields.extend([(x[0], jnp.int32) for x in self.bd_spec])
+            # Add extra bd state fields to help the calculation.
+            fields.extend(self.bd_state_spec)
+            return dataclass(dataclasses.make_dataclass(
+                type(task_state_def).__name__,
+                fields=fields, bases=task_state_def.__bases__, init=False))
+
+    def init_extended_state(self, task_state: TaskState) -> T:
+        """Return an extended task_state that includes bd_state fields.
+
+        Args:
+            task_state - Original task state.
+        Returns:
+            An instance of the extended task state.
+        """
+        bd_fields = {x[0]: jnp.zeros((), dtype=jnp.int32) for x in self.bd_spec}
+        bd_state = self.init_state(task_state)
+        return self.extended_task_state(
+            **bd_state,    # These keep track of the stats we need.
+            **bd_fields,   # These will be updated in self.summarize.
+            **task_state.__dict__)
+
+    def init_state(self, extended_task_state: T) -> Dict[str, T]:
+        """A task initializes some behavior descriptor related states here.
+
+        Args:
+            extended_task_state - An instance of the extended task state, with
+                                  dummy behavior descriptor related states.
+        Returns:
+            A dictionary that contains the initial values for each of the
+            behavior descriptor related states.
+        """
+        raise NotImplementedError()
+
+    def update(self,
+               extended_task_state: T,
+               action: jnp.ndarray,
+               reward: jnp.float32,
+               done: jnp.int32) -> T:
+        """Update behavior descriptor calculation states.
+
+        Args:
+            extended_task_state - An instance of extended task state.
+            action - The action taken at this step.
+            reward - The reward acquired at this step.
+            done - The termination flag from this step.
+        Returns:
+            The same instance of the extended task state, but with behavior
+            descriptor related states updated.
+        """
+        raise NotImplementedError()
+
+    def summarize(self, extended_task_state: T) -> T:
+        """Summarize the behavior descriptor related states to calculate BDs.
+
+        Args:
+            extended_task_state - An instance of the extended task state.
+        Returns:
+            The same instance, but with behavior descriptions calculated within.
         """
         raise NotImplementedError()

--- a/evojax/task/brax_task.py
+++ b/evojax/task/brax_task.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import sys
+from typing import Optional
 from typing import Tuple
 
 import jax
@@ -21,6 +22,7 @@ from flax.struct import dataclass
 
 from evojax.task.base import VectorizedTask
 from evojax.task.base import TaskState
+from evojax.task.base import BDExtractor
 
 try:
     from brax.envs import create
@@ -35,6 +37,7 @@ except ModuleNotFoundError:
 class State(TaskState):
     state: BraxState
     obs: jnp.ndarray
+    feet_contact: jnp.ndarray
 
 
 class BraxTask(VectorizedTask):
@@ -44,8 +47,10 @@ class BraxTask(VectorizedTask):
                  env_name: str,
                  max_steps: int = 1000,
                  legacy_spring: bool = True,
+                 bd_extractor: Optional[BDExtractor] = None,
                  test: bool = False):
         self.max_steps = max_steps
+        self.bd_extractor = bd_extractor
         self.test = test
         brax_env = create(
             env_name=env_name,
@@ -55,16 +60,31 @@ class BraxTask(VectorizedTask):
         self.obs_shape = tuple([brax_env.observation_size, ])
         self.act_shape = tuple([brax_env.action_size, ])
 
+        def detect_feet_contact(state, action):
+            _, info = brax_env.sys.step(state.qp, action)
+            has_contacts = jnp.abs(
+                jnp.clip(info.contact.vel, a_min=-1., a_max=1.)
+            ).sum(axis=-1) > 0
+            return has_contacts[2::2].astype(jnp.int32)
+
         def reset_fn(key):
             state = brax_env.reset(key)
-            return State(state=state, obs=state.obs)
-
+            state = State(state=state, obs=state.obs,
+                          feet_contact=jnp.zeros(4, dtype=jnp.int32))
+            if bd_extractor is not None:
+                state = bd_extractor.init_extended_state(state)
+            return state
         self._reset_fn = jax.jit(jax.vmap(reset_fn))
 
         def step_fn(state, action):
-            state = brax_env.step(state.state, action)
-            return State(state=state, obs=state.obs), state.reward, state.done
-
+            feet_contact = detect_feet_contact(state.state, action)
+            brax_state = brax_env.step(state.state, action)
+            state = state.replace(
+                state=brax_state, obs=brax_state.obs, feet_contact=feet_contact)
+            if bd_extractor is not None:
+                state = bd_extractor.update(
+                    state, action, brax_state.reward, brax_state.done)
+            return state, brax_state.reward, brax_state.done
         self._step_fn = jax.jit(jax.vmap(step_fn))
 
     def reset(self, key: jnp.ndarray) -> State:
@@ -74,3 +94,49 @@ class BraxTask(VectorizedTask):
              state: State,
              action: jnp.ndarray) -> Tuple[State, jnp.ndarray, jnp.ndarray]:
         return self._step_fn(state, action)
+
+
+class AntBDExtractor(BDExtractor):
+    """Behavior descriptor extractor for the Ant locomotion task."""
+
+    def __init__(self, logger):
+        # Each BD represents the quantized foot-ground contact time ratio.
+        bd_spec = [
+            ('feet1_contact', 10),
+            ('feet2_contact', 10),
+            ('feet3_contact', 10),
+            ('feet4_contact', 10),
+        ]
+        bd_state_spec = [
+            ('feet_contact_times', jnp.ndarray),
+            ('step_cnt', jnp.int32),
+            ('valid_mask', jnp.int32),
+        ]
+        super(AntBDExtractor, self).__init__(bd_spec, bd_state_spec, State)
+        self._logger = logger
+
+    def init_state(self, extended_task_state):
+        return {
+            'feet_contact_times': jnp.zeros_like(
+                extended_task_state.feet_contact, dtype=jnp.int32),
+            'step_cnt': jnp.zeros((), dtype=jnp.int32),
+            'valid_mask': jnp.ones((), dtype=jnp.int32),
+        }
+
+    def update(self, extended_task_state, action, reward, done):
+        valid_mask = (
+                extended_task_state.valid_mask * (1 - done)).astype(jnp.int32)
+        return extended_task_state.replace(
+            feet_contact_times=(
+                extended_task_state.feet_contact_times +
+                extended_task_state.feet_contact * valid_mask),
+            step_cnt=extended_task_state.step_cnt + valid_mask,
+            valid_mask=valid_mask)
+
+    def summarize(self, extended_task_state):
+        feet_contact_ratio = (
+            extended_task_state.feet_contact_times /
+            extended_task_state.step_cnt[..., None]).mean(axis=1)
+        bds = {bd[0]: (feet_contact_ratio[:, i] * bd[1]).astype(jnp.int32)
+               for i, bd in enumerate(self.bd_spec)}
+        return extended_task_state.replace(**bds)

--- a/evojax/util.py
+++ b/evojax/util.py
@@ -115,7 +115,21 @@ def save_model(model_dir: str,
                  obs_params=np.array(obs_params))
 
 
-def get_tensorboard_log_fn(log_dir: str) -> Callable[[int, jnp.ndarray, str], None]:
+def save_lattices(log_dir: str,
+                  file_name: str,
+                  fitness_lattice: jnp.ndarray,
+                  params_lattice: jnp.ndarray,
+                  occupancy_lattice: jnp.ndarray) -> None:
+    """Save QD method's lattices."""
+    file_name = os.path.join(log_dir, '{}.npz'.format(file_name))
+    np.savez(file_name,
+             params_lattice=np.array(params_lattice),
+             fitness_lattice=np.array(fitness_lattice),
+             occupancy_lattice=np.array(occupancy_lattice))
+
+
+def get_tensorboard_log_fn(
+        log_dir: str) -> Callable[[int, jnp.ndarray, str], None]:
     """
     Returns a custom logging function for the `evojax` `Trainer`.
     The function logs rewards after every train/test iteration with Tensorboard.
@@ -129,11 +143,17 @@ def get_tensorboard_log_fn(log_dir: str) -> Callable[[int, jnp.ndarray, str], No
 
         def log_with_pytorch(i: int, scores: jnp.ndarray, stage: str):
             with SummaryWriter(log_dir=log_dir) as writer:
-                writer.add_scalar(f"{stage}/score_min", scores.min().item(), global_step=i)
-                writer.add_scalar(f"{stage}/score_max", scores.max().item(), global_step=i)
-                writer.add_scalar(f"{stage}/score_mean", scores.mean().item(), global_step=i)
-                writer.add_scalar(f"{stage}/score_std", scores.std().item(), global_step=i)
-                writer.add_histogram(f"{stage}/score_distribution", np.array(scores), global_step=i)
+                writer.add_scalar(
+                    f"{stage}/score_min", scores.min().item(), global_step=i)
+                writer.add_scalar(
+                    f"{stage}/score_max", scores.max().item(), global_step=i)
+                writer.add_scalar(
+                    f"{stage}/score_mean", scores.mean().item(), global_step=i)
+                writer.add_scalar(
+                    f"{stage}/score_std", scores.std().item(), global_step=i)
+                writer.add_histogram(
+                    f"{stage}/score_distribution", np.array(scores),
+                    global_step=i)
 
         return log_with_pytorch
 
@@ -145,15 +165,22 @@ def get_tensorboard_log_fn(log_dir: str) -> Callable[[int, jnp.ndarray, str], No
 
         def log_with_tf(i: int, scores: jnp.ndarray, stage: str):
             with tf.summary.SummaryWriter(log_dir=log_dir).as_default():
-                tf.summary.scalar(f"{stage}/score_min", scores.min().item(), step=i)
-                tf.summary.scalar(f"{stage}/score_max", scores.max().item(), step=i)
-                tf.summary.scalar(f"{stage}/score_mean", scores.mean().item(), step=i)
-                tf.summary.scalar(f"{stage}/score_std", scores.std().item(), step=i)
-                tf.summary.histogram(f"{stage}/score_distribution", np.array(scores), step=i)
+                tf.summary.scalar(
+                    f"{stage}/score_min", scores.min().item(), step=i)
+                tf.summary.scalar(
+                    f"{stage}/score_max", scores.max().item(), step=i)
+                tf.summary.scalar(
+                    f"{stage}/score_mean", scores.mean().item(), step=i)
+                tf.summary.scalar(
+                    f"{stage}/score_std", scores.std().item(), step=i)
+                tf.summary.histogram(
+                    f"{stage}/score_distribution", np.array(scores), step=i)
 
         return log_with_tf
 
     except ImportError:
         pass
 
-    raise ImportError("Please install the tensorboard AND (tensorflow OR pytorch) packages to log the rewards to tensorboard")
+    raise ImportError(
+        "Please install the tensorboard AND (tensorflow OR pytorch) "
+        "packages to log the rewards to tensorboard")

--- a/examples/train_ant_map_elites.py
+++ b/examples/train_ant_map_elites.py
@@ -14,7 +14,7 @@
 
 """Train an ant locomotion controller with MAP-Elites.
 
-To define a different behavior descriptor extractors, see BraxTask for example.
+To define a different BD extractor, see task/brax_task.py for example.
 
 Example command:
 python train_ant_map_elites.py --max-iter=3000

--- a/examples/train_ant_map_elites.py
+++ b/examples/train_ant_map_elites.py
@@ -1,0 +1,200 @@
+# Copyright 2022 The EvoJAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Train an ant locomotion controller with MAP-Elites.
+
+To define a different behavior descriptor extractors, see BraxTask for example.
+
+Example command:
+python train_ant_map_elites.py --max-iter=3000
+python train_ant_map_elites.py --max-iter=3000 --save-gif  # May cost some time.
+"""
+
+import argparse
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+from PIL import Image
+from functools import partial
+
+from evojax import Trainer
+from evojax.task.brax_task import BraxTask
+from evojax.task.brax_task import AntBDExtractor
+from evojax.policy import MLPPolicy
+from evojax.algo import MAPElites
+from evojax import util
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--pop-size', type=int, default=1024, help='NE population size.')
+    parser.add_argument(
+        '--num-tests', type=int, default=128, help='Number of test rollouts.')
+    parser.add_argument(
+        '--n-repeats', type=int, default=8, help='Training repetitions.')
+    parser.add_argument(
+        '--max-iter', type=int, default=300, help='Max training iterations.')
+    parser.add_argument(
+        '--test-interval', type=int, default=50, help='Test interval.')
+    parser.add_argument(
+        '--log-interval', type=int, default=10, help='Logging interval.')
+    parser.add_argument(
+        '--seed', type=int, default=42, help='Random seed for training.')
+    parser.add_argument(
+        '--iso-sigma', type=float, default=0.05, help='Iso sigma.')
+    parser.add_argument(
+        '--line-sigma', type=float, default=0.3, help='Line sigma.')
+    parser.add_argument(
+        '--gpu-id', type=str, help='GPU(s) to use.')
+    parser.add_argument(
+        '--debug', action='store_true', help='Debug mode.')
+    parser.add_argument(
+        '--save-gif', action='store_true', help='Save some GIFs.')
+    config, _ = parser.parse_known_args()
+    return config
+
+
+def plot_figure(lattice, log_dir, title):
+    grid = lattice.reshape((10, 10, 10, 10))
+    fig, axes = plt.subplots(10, 10, figsize=(8, 8))
+    for i in range(10):
+        for j in range(10):
+            ax = axes[i][j]
+            ax.imshow(grid[i, j])
+            ax.set_axis_off()
+    fig.suptitle(title, fontsize=20, fontweight='bold')
+    plt.savefig(os.path.join(log_dir, '{}.png'.format(title)))
+
+
+def main(config):
+    log_dir = './log/ant_map_elites'
+    if not os.path.exists(log_dir):
+        os.makedirs(log_dir, exist_ok=True)
+    logger = util.create_logger(
+        name='AntMapElites', log_dir=log_dir, debug=config.debug)
+
+    logger.info('EvoJAX AntMapElites Demo')
+    logger.info('=' * 30)
+
+    bd_extractor = AntBDExtractor(logger=logger)
+    train_task = BraxTask(
+        env_name='ant', max_steps=500, bd_extractor=bd_extractor, test=False)
+    test_task = BraxTask(
+        env_name='ant', bd_extractor=bd_extractor, test=True)
+    policy = MLPPolicy(
+        input_dim=train_task.obs_shape[0],
+        hidden_dims=[32, 32, 32, 32],
+        output_dim=train_task.act_shape[0],
+    )
+    solver = MAPElites(
+        pop_size=config.pop_size,
+        param_size=policy.num_params,
+        bd_extractor=bd_extractor,
+        iso_sigma=config.iso_sigma,
+        line_sigma=config.line_sigma,
+        seed=config.seed,
+        logger=logger,
+    )
+
+    # Train.
+    trainer = Trainer(
+        policy=policy,
+        solver=solver,
+        train_task=train_task,
+        test_task=test_task,
+        max_iter=config.max_iter,
+        log_interval=config.log_interval,
+        test_interval=config.test_interval,
+        n_repeats=config.n_repeats,
+        n_evaluations=config.num_tests,
+        seed=config.seed,
+        log_dir=log_dir,
+        logger=logger,
+    )
+    trainer.run(demo_mode=False)
+
+    # Visualize the results.
+    qd_file = os.path.join(log_dir, 'qd_lattices.npz')
+    with open(qd_file, 'rb') as f:
+        data = np.load(f)
+        params_lattice = data['params_lattice']
+        fitness_lattice = data['fitness_lattice']
+        occupancy_lattice = data['occupancy_lattice']
+    plot_figure(occupancy_lattice, log_dir, 'occupancy')
+    plot_figure(fitness_lattice, log_dir, 'score')
+
+    # Visualize the top policies.
+    if config.save_gif:
+        import jax
+        import jax.numpy as jnp
+        from brax import envs
+        from brax.io import image
+
+        @partial(jax.jit, static_argnums=(1,))
+        def get_qp(state, ix):
+            return jax.tree_map(lambda x: x[ix], state.qp)
+
+        num_viz = 3
+        idx = fitness_lattice.argsort()[-num_viz:]
+        bins = [np.unravel_index(ix, (10, 10, 10, 10)) for ix in idx]
+        logger.info(
+            'Best {} policies: indices={}, bins={}'.format(num_viz, idx, bins))
+
+        policy_params = jnp.array(params_lattice[idx])
+        task_reset_fn = jax.jit(test_task.reset)
+        policy_reset_fn = jax.jit(policy.reset)
+        step_fn = jax.jit(test_task.step)
+        act_fn = jax.jit(policy.get_actions)
+
+        total_reward = jnp.zeros(num_viz)
+        valid_masks = jnp.ones(num_viz)
+        rollouts = {i: [] for i in range(num_viz)}
+        keys = jnp.repeat(
+            jax.random.PRNGKey(seed=42)[None, :], repeats=num_viz, axis=0)
+        task_state = task_reset_fn(key=keys)
+        policy_state = policy_reset_fn(task_state)
+
+        for step in range(test_task.max_steps):
+            for i in range(num_viz):
+                rollouts[i].append(get_qp(task_state.state, i))
+            act, policy_state = act_fn(task_state, policy_params, policy_state)
+            task_state, reward, done = step_fn(task_state, act)
+            total_reward = total_reward + reward * valid_masks
+            valid_masks = valid_masks * (1 - done)
+        logger.info('test_rewards={}'.format(total_reward))
+
+        logger.info('Start saving GIFs, this can take some time ...')
+        env_fn = envs.create_fn(env_name='ant', legacy_spring=True)
+        env = env_fn()
+        for i in range(num_viz):
+            qps = jax.tree_map(lambda x: np.array(x), rollouts[i])
+            frames = [
+                Image.fromarray(
+                    image.render_array(env.sys, qp, 320, 240, None, None, 2))
+                for qp in qps]
+            frames[0].save(
+                os.path.join(log_dir, 'bin_{}.gif'.format(bins[i])),
+                format='png',
+                append_images=frames[1:],
+                save_all=True,
+                duration=env.sys.config.dt * 1000,
+                loop=0)
+
+
+if __name__ == '__main__':
+    configs = parse_args()
+    if configs.gpu_id is not None:
+        os.environ['CUDA_VISIBLE_DEVICES'] = configs.gpu_id
+    main(configs)

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         "jaxlib>=0.1.65",
         "Pillow",
         "cma",
+        "matplotlib",
     ],
     extras_require={
         "extra": ['evosax', 'torchvision', 'pandas', 'procgen', 'brax'],


### PR DESCRIPTION
Add a simple implementation of the MAP-Elites algorithm ([ref1](https://arxiv.org/abs/1504.04909), [ref2](https://arxiv.org/abs/2202.01258)), with an example on the Brax Ant task.
Users can implement their own behavior descriptor extractor, see an example in `task/brax_task.py`.

Example commands
```shell
python train_ant_map_elites.py --max-iter=3000
python train_ant_map_elites.py --max-iter=3000 --save-gif  # This can be slow
```

Example output
<table width="100%">
  <tr>
    <td width="45%">
<img src=https://user-images.githubusercontent.com/2889514/170271767-82b8cef6-dc9b-455e-898f-85ebc2883dbe.png />
</td>
    <td width="55%">
<img src=https://user-images.githubusercontent.com/2889514/170272057-5bb1253a-0281-48e5-a998-9bec54f6a1f2.png />
</td>
</tr>
</table>

**Note** We plan to add more Quality Diversity methods, the implementations and related interfaces are subject to change.
