### PR TITLE
Update for `evosax` API changes

### DIFF
--- a/evojax/algo/ars.py
+++ b/evojax/algo/ars.py
@@ -93,14 +93,18 @@ class ARS(NEAlgorithm):
         )
 
         # Set hyperparameters according to provided inputs
-        self.es_params = self.es.default_params
-        for k, v in optimizer_config.items():
-            self.es_params[k] = v
-        self.es_params["sigma_init"] = init_stdev
-        self.es_params["sigma_decay"] = decay_stdev
-        self.es_params["sigma_limit"] = limit_stdev
-        self.es_params["init_min"] = 0.0
-        self.es_params["init_max"] = 0.0
+        self.es_params = self.es.default_params.replace(
+            sigma_init=init_stdev,
+            sigma_decay=decay_stdev,
+            sigma_limit=limit_stdev,
+            init_min=0.0,
+            init_max=0.0,
+        )
+
+        # Update optimizer-specific parameters of Adam
+        self.es_params = self.es_params.replace(
+            opt_params=self.es_params.opt_params.replace(**optimizer_config)
+        )
 
         # Initialize the evolution strategy state
         self.rand_key, init_key = jax.random.split(self.rand_key)
@@ -126,9 +130,11 @@ class ARS(NEAlgorithm):
 
     @property
     def best_params(self) -> jnp.ndarray:
-        return jnp.array(self.es_state["mean"], copy=True)
+        return jnp.array(self.es_state.mean, copy=True)
 
     @best_params.setter
     def best_params(self, params: Union[np.ndarray, jnp.ndarray]) -> None:
-        self.es_state["best_member"] = jnp.array(params, copy=True)
-        self.es_state["mean"] = jnp.array(params, copy=True)
+        self.es_state = self.es_state.replace(
+            best_member=jnp.array(params, copy=True),
+            mean=jnp.array(params, copy=True),
+        )

--- a/evojax/algo/cma_evosax.py
+++ b/evojax/algo/cma_evosax.py
@@ -72,8 +72,7 @@ class CMA_ES(NEAlgorithm):
         )
 
         # Set hyperparameters according to provided inputs
-        self.es_params = self.es.default_params
-        self.es_params["sigma_init"] = init_stdev
+        self.es_params = self.es.default_params.replace(sigma_init=init_stdev)
 
         # Initialize the evolution strategy state
         self.rand_key, init_key = jax.random.split(self.rand_key)
@@ -99,9 +98,11 @@ class CMA_ES(NEAlgorithm):
 
     @property
     def best_params(self) -> jnp.ndarray:
-        return jnp.array(self.es_state["mean"], copy=True)
+        return jnp.array(self.es_state.mean, copy=True)
 
     @best_params.setter
     def best_params(self, params: Union[np.ndarray, jnp.ndarray]) -> None:
-        self.es_state["best_member"] = jnp.array(params, copy=True)
-        self.es_state["mean"] = jnp.array(params, copy=True)
+        self.es_state = self.es_state.replace(
+            best_member=jnp.array(params, copy=True),
+            mean=jnp.array(params, copy=True),
+        )

--- a/evojax/algo/sep_cma_es.py
+++ b/evojax/algo/sep_cma_es.py
@@ -72,8 +72,7 @@ class Sep_CMA_ES(NEAlgorithm):
         )
 
         # Set hyperparameters according to provided inputs
-        self.es_params = self.es.default_params
-        self.es_params["sigma_init"] = init_stdev
+        self.es_params = self.es.default_params.replace(sigma_init=init_stdev)
 
         # Initialize the evolution strategy state
         self.rand_key, init_key = jax.random.split(self.rand_key)
@@ -99,9 +98,11 @@ class Sep_CMA_ES(NEAlgorithm):
 
     @property
     def best_params(self) -> jnp.ndarray:
-        return jnp.array(self.es_state["mean"], copy=True)
+        return jnp.array(self.es_state.mean, copy=True)
 
     @best_params.setter
     def best_params(self, params: Union[np.ndarray, jnp.ndarray]) -> None:
-        self.es_state["best_member"] = jnp.array(params, copy=True)
-        self.es_state["mean"] = jnp.array(params, copy=True)
+        self.es_state = self.es_state.replace(
+            best_member=jnp.array(params, copy=True),
+            mean=jnp.array(params, copy=True),
+        )


### PR DESCRIPTION
Updates the strategies, which rely on the `evosax` backend after some minor frontend changes in [version `0.0.9`](https://github.com/RobertTLange/evosax/releases/tag/v0.0.9).  The `evoJAX` frontend stays untouched and the strategy functionalities internally have also not changed. But `evosax` internally now uses `flax`-based dataclasses for the state (`EvoState`) and hyperparameters (`EvoParams`), which make type-checking easier and have all the benefits of immutable states, etc.