### PR TITLE
Evosax - iAMaLGaM

### DIFF
--- a/evojax/algo/__init__.py
+++ b/evojax/algo/__init__.py
@@ -23,6 +23,7 @@ from .cma_evosax import CMA_ES
 from .sep_cma_es import Sep_CMA_ES
 from .cma_jax import CMA_ES_JAX
 from .map_elites import MAPElites
+from .iamalgam import iAMaLGaM
 
 Strategies = {
     "CMA": CMA,
@@ -34,6 +35,7 @@ Strategies = {
     "Sep_CMA_ES": Sep_CMA_ES,
     "CMA_ES_JAX": CMA_ES_JAX,
     "MAPElites": MAPElites,
+    "iAMaLGaM": iAMaLGaM,
 }
 
 __all__ = [
@@ -48,5 +50,6 @@ __all__ = [
     "Sep_CMA_ES",
     "CMA_ES_JAX",
     "MAPElites",
+    "iAMaLGaM",
     "Strategies",
 ]

--- a/evojax/algo/ars.py
+++ b/evojax/algo/ars.py
@@ -93,14 +93,18 @@ class ARS(NEAlgorithm):
         )
 
         # Set hyperparameters according to provided inputs
-        self.es_params = self.es.default_params
-        for k, v in optimizer_config.items():
-            self.es_params[k] = v
-        self.es_params["sigma_init"] = init_stdev
-        self.es_params["sigma_decay"] = decay_stdev
-        self.es_params["sigma_limit"] = limit_stdev
-        self.es_params["init_min"] = 0.0
-        self.es_params["init_max"] = 0.0
+        self.es_params = self.es.default_params.replace(
+            sigma_init=init_stdev,
+            sigma_decay=decay_stdev,
+            sigma_limit=limit_stdev,
+            init_min=0.0,
+            init_max=0.0,
+        )
+
+        # Update optimizer-specific parameters of Adam
+        self.es_params = self.es_params.replace(
+            opt_params=self.es_params.opt_params.replace(**optimizer_config)
+        )
 
         # Initialize the evolution strategy state
         self.rand_key, init_key = jax.random.split(self.rand_key)
@@ -126,9 +130,11 @@ class ARS(NEAlgorithm):
 
     @property
     def best_params(self) -> jnp.ndarray:
-        return jnp.array(self.es_state["mean"], copy=True)
+        return jnp.array(self.es_state.mean, copy=True)
 
     @best_params.setter
     def best_params(self, params: Union[np.ndarray, jnp.ndarray]) -> None:
-        self.es_state["best_member"] = jnp.array(params, copy=True)
-        self.es_state["mean"] = jnp.array(params, copy=True)
+        self.es_state = self.es_state.replace(
+            best_member=jnp.array(params, copy=True),
+            mean=jnp.array(params, copy=True),
+        )

--- a/evojax/algo/cma_evosax.py
+++ b/evojax/algo/cma_evosax.py
@@ -72,8 +72,7 @@ class CMA_ES(NEAlgorithm):
         )
 
         # Set hyperparameters according to provided inputs
-        self.es_params = self.es.default_params
-        self.es_params["sigma_init"] = init_stdev
+        self.es_params = self.es.default_params.replace(sigma_init=init_stdev)
 
         # Initialize the evolution strategy state
         self.rand_key, init_key = jax.random.split(self.rand_key)
@@ -99,9 +98,11 @@ class CMA_ES(NEAlgorithm):
 
     @property
     def best_params(self) -> jnp.ndarray:
-        return jnp.array(self.es_state["mean"], copy=True)
+        return jnp.array(self.es_state.mean, copy=True)
 
     @best_params.setter
     def best_params(self, params: Union[np.ndarray, jnp.ndarray]) -> None:
-        self.es_state["best_member"] = jnp.array(params, copy=True)
-        self.es_state["mean"] = jnp.array(params, copy=True)
+        self.es_state = self.es_state.replace(
+            best_member=jnp.array(params, copy=True),
+            mean=jnp.array(params, copy=True),
+        )

--- a/evojax/algo/iamalgam.py
+++ b/evojax/algo/iamalgam.py
@@ -1,0 +1,125 @@
+import sys
+
+import logging
+from typing import Union
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+from evojax.algo.base import NEAlgorithm
+from evojax.util import create_logger
+
+
+class iAMaLGaM(NEAlgorithm):
+    """A wrapper around evosax's iAMaLGaM.
+    Implementation: https://github.com/RobertTLange/evosax/blob/main/evosax/strategies/indep_iamalgam.py
+    Reference: Bosman et al. (2013) - https://tinyurl.com/y9fcccx2
+    """
+
+    def __init__(
+        self,
+        param_size: int,
+        pop_size: int,
+        elite_ratio: float = 0.35,
+        full_covariance: bool = False,
+        init_stdev: float = 0.01,
+        decay_stdev: float = 0.999,
+        limit_stdev: float = 0.001,
+        w_decay: float = 0.0,
+        seed: int = 0,
+        logger: logging.Logger = None,
+    ):
+        """Initialization function.
+
+        Args:
+            param_size - Parameter size.
+            pop_size - Population size.
+            elite_ratio - Population elite fraction used for mean update.
+            full_covariance - Whether to estimate full covariance or only diag.
+            init_stdev - Initial scale of Gaussian perturbation.
+            decay_stdev - Multiplicative scale decay between tell iterations.
+            limit_stdev - Smallest scale (clipping limit).
+            w_decay - L2 weight regularization coefficient.
+            seed - Random seed for parameters sampling.
+            logger - Logger.
+        """
+
+        # Delayed importing of evosax
+
+        if sys.version_info.minor < 7:
+            print(
+                "evosax, which is needed by Augmented Random Search, requires"
+                " python>=3.7"
+            )
+            print("  please consider upgrading your Python version.")
+            sys.exit(1)
+
+        try:
+            import evosax
+        except ModuleNotFoundError:
+            print("You need to install evosax for its Augmented Random Search:")
+            print("  pip install evosax")
+            sys.exit(1)
+
+        # Set up object variables.
+
+        if logger is None:
+            self.logger = create_logger(name="iAMaLGaM")
+        else:
+            self.logger = logger
+
+        self.param_size = param_size
+        self.pop_size = abs(pop_size)
+        self.rand_key = jax.random.PRNGKey(seed=seed)
+
+        # Instantiate evosax's iAMaLGaM strategy
+        if full_covariance:
+            self.es = evosax.Full_iAMaLGaM(
+                popsize=pop_size, num_dims=param_size, elite_ratio=elite_ratio
+            )
+        else:
+            self.es = evosax.Indep_iAMaLGaM(
+                popsize=pop_size, num_dims=param_size, elite_ratio=elite_ratio
+            )
+
+        # Set hyperparameters according to provided inputs
+        self.es_params = self.es.default_params.replace(
+            sigma_init=init_stdev,
+            sigma_decay=decay_stdev,
+            sigma_limit=limit_stdev,
+            init_min=0.0,
+            init_max=0.0,
+        )
+
+        # Initialize the evolution strategy state
+        self.rand_key, init_key = jax.random.split(self.rand_key)
+        self.es_state = self.es.initialize(init_key, self.es_params)
+
+        # By default evojax assumes maximization of fitness score!
+        # Evosax, on the other hand, minimizes!
+        self.fit_shaper = evosax.FitnessShaper(w_decay=w_decay, maximize=True)
+
+    def ask(self) -> jnp.ndarray:
+        self.rand_key, ask_key = jax.random.split(self.rand_key)
+        self.params, self.es_state = self.es.ask(
+            ask_key, self.es_state, self.es_params
+        )
+        return self.params
+
+    def tell(self, fitness: Union[np.ndarray, jnp.ndarray]) -> None:
+        # Reshape fitness to conform with evosax minimization
+        fit_re = self.fit_shaper.apply(self.params, fitness)
+        self.es_state = self.es.tell(
+            self.params, fit_re, self.es_state, self.es_params
+        )
+
+    @property
+    def best_params(self) -> jnp.ndarray:
+        return jnp.array(self.es_state.mean, copy=True)
+
+    @best_params.setter
+    def best_params(self, params: Union[np.ndarray, jnp.ndarray]) -> None:
+        self.es_state = self.es_state.replace(
+            best_member=jnp.array(params, copy=True),
+            mean=jnp.array(params, copy=True),
+        )

--- a/evojax/algo/sep_cma_es.py
+++ b/evojax/algo/sep_cma_es.py
@@ -72,8 +72,7 @@ class Sep_CMA_ES(NEAlgorithm):
         )
 
         # Set hyperparameters according to provided inputs
-        self.es_params = self.es.default_params
-        self.es_params["sigma_init"] = init_stdev
+        self.es_params = self.es.default_params.replace(sigma_init=init_stdev)
 
         # Initialize the evolution strategy state
         self.rand_key, init_key = jax.random.split(self.rand_key)
@@ -99,9 +98,11 @@ class Sep_CMA_ES(NEAlgorithm):
 
     @property
     def best_params(self) -> jnp.ndarray:
-        return jnp.array(self.es_state["mean"], copy=True)
+        return jnp.array(self.es_state.mean, copy=True)
 
     @best_params.setter
     def best_params(self, params: Union[np.ndarray, jnp.ndarray]) -> None:
-        self.es_state["best_member"] = jnp.array(params, copy=True)
-        self.es_state["mean"] = jnp.array(params, copy=True)
+        self.es_state = self.es_state.replace(
+            best_member=jnp.array(params, copy=True),
+            mean=jnp.array(params, copy=True),
+        )

--- a/scripts/benchmarks/Readme.md
+++ b/scripts/benchmarks/Readme.md
@@ -63,6 +63,17 @@ This will sequentially execute 25 ARS-MNIST evolution runs for a grid of differe
 
 |   | Benchmarks | Parameters | Results (Avg) |
 |---|---|---|---|
+CartPole (easy) | 	900 (max_iter=1000)|[Link](configs/iAMaLGaM/cartpole_easy.yaml)| 919.2294 |
+CartPole (hard)	| 600 (max_iter=1000)|[Link](configs/iAMaLGaM/cartpole_hard.yaml)| 620.8969 |
+Waterworld	| 6 (max_iter=1000)	 | [Link](configs/iAMaLGaM/waterworld.yaml)| 9.53 |
+Waterworld (MA)	| 2 (max_iter=2000)	| [Link](configs/iAMaLGaM/waterworld_ma.yaml) | - |
+MNIST	| 0.90 (max_iter=2000)	| [Link](configs/iAMaLGaM/mnist.yaml)| - |
+Brax Ant |	3000 (max_iter=1200) |[Link](configs/iAMaLGaM/brax_ant.yaml)| - |
+
+### CMA-ES
+
+|   | Benchmarks | Parameters | Results (Avg) |
+|---|---|---|---|
 CartPole (easy) | 	900 (max_iter=1000)|[Link](configs/CMA_ES/cartpole_easy.yaml)| 927.3208 |
 CartPole (hard)	| 600 (max_iter=1000)|[Link](configs/CMA_ES/cartpole_hard.yaml)| 625.9829 |
 MNIST	| 0.90 (max_iter=2000)	| [Link](configs/CMA_ES/mnist.yaml)| 0.9581 |

--- a/scripts/benchmarks/configs/iAMaLGaM/brax_ant.yaml
+++ b/scripts/benchmarks/configs/iAMaLGaM/brax_ant.yaml
@@ -1,0 +1,19 @@
+es_name: "iAMaLGaM"
+problem_type: "brax"
+env_name: "ant"
+normalize: true
+es_config:
+  full_covariance: false
+  elite_ratio: 0.35
+  pop_size: 512
+  init_stdev: 0.0
+  decay_stdev: 0.999
+  limit_stdev: 0.0
+num_tests: 128
+n_repeats: 16
+max_iter: 600
+test_interval: 100
+log_interval: 20
+seed: 42
+gpu_id: [0, 1, 2, 3]
+debug: false

--- a/scripts/benchmarks/configs/iAMaLGaM/cartpole_easy.yaml
+++ b/scripts/benchmarks/configs/iAMaLGaM/cartpole_easy.yaml
@@ -1,0 +1,19 @@
+es_name: "iAMaLGaM"
+problem_type: "cartpole_easy"
+normalize: false
+es_config:
+  full_covariance: false
+  elite_ratio: 0.35
+  pop_size: 100
+  init_stdev: 0.0
+  decay_stdev: 0.999
+  limit_stdev: 0.0
+hidden_size: 64
+num_tests: 100
+n_repeats: 16
+max_iter: 1000
+test_interval: 100
+log_interval: 50
+seed: 42
+gpu_id: 0
+debug: false

--- a/scripts/benchmarks/configs/iAMaLGaM/cartpole_hard.yaml
+++ b/scripts/benchmarks/configs/iAMaLGaM/cartpole_hard.yaml
@@ -1,0 +1,19 @@
+es_name: "iAMaLGaM"
+problem_type: "cartpole_hard"
+normalize: false
+es_config:
+  full_covariance: false
+  elite_ratio: 0.35
+  pop_size: 100
+  init_stdev: 0.0
+  decay_stdev: 0.999
+  limit_stdev: 0.0
+hidden_size: 64
+num_tests: 100
+n_repeats: 16
+max_iter: 1000
+test_interval: 100
+log_interval: 20
+seed: 42
+gpu_id: 0
+debug: false

--- a/scripts/benchmarks/configs/iAMaLGaM/mnist.yaml
+++ b/scripts/benchmarks/configs/iAMaLGaM/mnist.yaml
@@ -1,0 +1,20 @@
+es_name: "iAMaLGaM"
+problem_type: "mnist"
+normalize: false
+es_config:
+  full_covariance: true
+  elite_ratio: 0.35
+  pop_size: 100
+  init_stdev: 0.0
+  decay_stdev: 0.999
+  limit_stdev: 0.0
+hidden_size: 100
+batch_size: 1024
+max_iter: 2000
+test_interval: 500
+log_interval: 100
+num_tests: 1
+n_repeats: 1
+seed: 42
+gpu_id: [0]
+debug: false

--- a/scripts/benchmarks/configs/iAMaLGaM/waterworld.yaml
+++ b/scripts/benchmarks/configs/iAMaLGaM/waterworld.yaml
@@ -1,0 +1,19 @@
+es_name: "iAMaLGaM"
+problem_type: "waterworld"
+normalize: false
+es_config:
+  full_covariance: false
+  elite_ratio: 0.35
+  pop_size: 256
+  init_stdev: 0.0
+  decay_stdev: 0.999
+  limit_stdev: 0.0
+hidden_size: 100
+num_tests: 100
+n_repeats: 32
+max_iter: 1000
+test_interval: 50
+log_interval: 10
+seed: 42
+gpu_id: [0, 1, 2, 3]
+debug: false

--- a/scripts/benchmarks/configs/iAMaLGaM/waterworld_ma.yaml
+++ b/scripts/benchmarks/configs/iAMaLGaM/waterworld_ma.yaml
@@ -1,0 +1,19 @@
+es_name: "iAMaLGaM"
+problem_type: "waterworld_ma"
+normalize: false
+es_config:
+  full_covariance: false
+  elite_ratio: 0.35
+  pop_size: 16
+  init_stdev: 0.0
+  decay_stdev: 0.999
+  limit_stdev: 0.0
+hidden_size: 100
+num_tests: 16
+n_repeats: 64
+max_iter: 2000
+test_interval: 100
+log_interval: 10
+seed: 42
+gpu_id: 0
+debug: false


### PR DESCRIPTION
- Reference: [Bosman et al. (2013)](https://homepages.cwi.nl/~bosman/publications/2013_benchmarkingparameterfree.pdf)
- `evosax` Source Code: https://github.com/RobertTLange/evosax/blob/main/evosax/strategies/full_iamalgam.py
- This PR adds a JAX-based iAMaLGaMversion, which runs on different hardware backends (CPU, GPU, TPU). It leverages anticipated mean shift, adaptive variance scaling and can either iteratively estimate the full covariance or a diagonal version.
- Benchmarks and hyperparameters:

|   | Benchmarks | Parameters | Results (Avg) |
|---|---|---|---|
CartPole (easy) | 	900 (max_iter=1000)|[Link](configs/iAMaLGaM/cartpole_easy.yaml)| 919.2294 |
CartPole (hard)	| 600 (max_iter=1000)|[Link](configs/iAMaLGaM/cartpole_hard.yaml)| 620.8969 |
Waterworld	| 6 (max_iter=1000)	 | [Link](configs/iAMaLGaM/waterworld.yaml)| 9.53 |

- It struggles with the harder Brax task and larger parameter search spaces in MNIST. At this point I am not entirely sure if this is due to a lack of scalability of the method or problems related to hyperparameter exploration.
- Finally, I ran into problems when trying to execute the experiments for the multi-agent Waterworld task on a 4 GPU machine (see cmdline output below):

```
  File "/cognition/home/RobTLange/anaconda/envs/snippets/lib/python3.8/site-packages/jax/_src/lax/utils.py", line 66, in standard_abstract_eval
    return core.ShapedArray(shape_rule(*avals, **kwargs),
  File "/cognition/home/RobTLange/anaconda/envs/snippets/lib/python3.8/site-packages/jax/_src/lax/lax.py", line 3015, in _reshape_shape_rule
    if not core.same_shape_sizes(np.shape(operand), new_sizes):
  File "/cognition/home/RobTLange/anaconda/envs/snippets/lib/python3.8/site-packages/jax/core.py", line 1519, in same_shape_sizes
    return 1 == divide_shape_sizes(s1, s2)
  File "/cognition/home/RobTLange/anaconda/envs/snippets/lib/python3.8/site-packages/jax/core.py", line 1516, in divide_shape_sizes
    return handler.divide_shape_sizes(ds[:len(s1)], ds[len(s1):])
  File "/cognition/home/RobTLange/anaconda/envs/snippets/lib/python3.8/site-packages/jax/core.py", line 1420, in divide_shape_sizes
    raise InconclusiveDimensionOperation(f"Cannot divide evenly the sizes of shapes {tuple(s1)} and {tuple(s2)}")
jax.core.InconclusiveDimensionOperation: Cannot divide evenly the sizes of shapes (64, 16) and (16, 64, 16)
```