### PR TITLE
fix bug for non-ant brax envs failing

### DIFF
--- a/evojax/task/brax_task.py
+++ b/evojax/task/brax_task.py
@@ -41,14 +41,16 @@ class State(TaskState):
 
 
 @dataclass
-class ExtendedState(State):
-    # Add states for map elites here.
+class BDExtractorState(TaskState):
+    # Add feet_contact state for map elites here.
+    state: BraxState
+    obs: jnp.ndarray
     feet_contact: jnp.ndarray
 
 
 def get_state_dataclass(**states):
     if 'feet_contact' in states:
-        return ExtendedState(**states)
+        return BDExtractorState(**states)
     else:
         return State(**states)
 
@@ -116,12 +118,12 @@ class BraxTask(VectorizedTask):
 
         self._step_fn = jax.jit(jax.vmap(step_fn))
 
-    def reset(self, key: jnp.ndarray) -> Union[State, ExtendedState]:
+    def reset(self, key: jnp.ndarray) -> Union[State, BDExtractorState]:
         return self._reset_fn(key)
 
     def step(self,
-             state: Union[State, ExtendedState],
-             action: jnp.ndarray) -> Tuple[Union[State, ExtendedState], jnp.ndarray, jnp.ndarray]:
+             state: Union[State, BDExtractorState],
+             action: jnp.ndarray) -> Tuple[Union[State, BDExtractorState], jnp.ndarray, jnp.ndarray]:
         return self._step_fn(state, action)
 
 
@@ -141,7 +143,7 @@ class AntBDExtractor(BDExtractor):
             ('step_cnt', jnp.int32),
             ('valid_mask', jnp.int32),
         ]
-        super(AntBDExtractor, self).__init__(bd_spec, bd_state_spec, ExtendedState)
+        super(AntBDExtractor, self).__init__(bd_spec, bd_state_spec, BDExtractorState)
         self._logger = logger
 
     def init_state(self, extended_task_state):

--- a/scripts/benchmarks/configs/PGPE/brax_test.yaml
+++ b/scripts/benchmarks/configs/PGPE/brax_test.yaml
@@ -1,0 +1,19 @@
+es_name: "PGPE"
+problem_type: "brax"
+env_name: "ant"
+normalize: true
+es_config:
+  pop_size: 128
+  center_learning_rate: 0.01
+  stdev_learning_rate: 0.07
+  init_stdev: 0.04
+  optimizer: "adam"
+hidden_size: 64
+num_tests: 1
+n_repeats: 1
+max_iter: 1
+test_interval: 1
+log_interval: 1
+seed: 42
+gpu_id: [0, 1, 2, 3]
+debug: false


### PR DESCRIPTION
### Summary
Pull request to fix bug outlined in #38 
Please let me know if you have any concerns relating to this PR. 

### Fixes
As outlined in #38 , the fix isolates code between the map-elites specific changes versus the other algorithms in `evojax/task/brax_task.py`
Created a seperate `TaskState` dataclass to handle additional arguments required for map-elites.
Mostly revert general functionality to precommit of #33 

### Tests
Tested on `examples/train_ant_map_elites.py`
Tested on 'scripts/benchmarks/train.py' with PGPE algorithm and a modified config file included in PR.
Not tested on other algorithms. 
