### PR TITLE
add CR-FM-NES algorithm

### DIFF
--- a/evojax/algo/__init__.py
+++ b/evojax/algo/__init__.py
@@ -24,6 +24,7 @@ from .sep_cma_es import Sep_CMA_ES
 from .cma_jax import CMA_ES_JAX
 from .map_elites import MAPElites
 from .iamalgam import iAMaLGaM
+from .fcrfmc import FCRFMC
 
 Strategies = {
     "CMA": CMA,
@@ -36,6 +37,7 @@ Strategies = {
     "CMA_ES_JAX": CMA_ES_JAX,
     "MAPElites": MAPElites,
     "iAMaLGaM": iAMaLGaM,
+    "FCRFMC": FCRFMC,
 }
 
 __all__ = [
@@ -51,5 +53,6 @@ __all__ = [
     "CMA_ES_JAX",
     "MAPElites",
     "iAMaLGaM",
+    "FCRFMC",
     "Strategies",
 ]

--- a/evojax/algo/fcrfmc.py
+++ b/evojax/algo/fcrfmc.py
@@ -87,4 +87,3 @@ class FCRFMC(NEAlgorithm):
     @best_params.setter
     def best_params(self, params: Union[np.ndarray, jnp.ndarray]) -> None:
         self._best_params = np.array(params)
-        self.cma.x0 = self._best_params.copy()

--- a/evojax/algo/fcrfmc.py
+++ b/evojax/algo/fcrfmc.py
@@ -49,6 +49,7 @@ class FCRFMC(NEAlgorithm):
 
         try:
             from scipy.optimize import Bounds
+            from numpy.random import MT19937, Generator
             from fcmaes import crfmnescpp
 
         except ModuleNotFoundError:
@@ -57,7 +58,7 @@ class FCRFMC(NEAlgorithm):
             sys.exit(1)
                  
         self.fcrfm = crfmnescpp.CRFMNES_C(param_size, None, [0.]*param_size,
-                init_stdev, pop_size)    
+                init_stdev, pop_size, Generator(MT19937(seed)))    
 
         self.params = None
         self._best_params = None

--- a/evojax/algo/fcrfmc.py
+++ b/evojax/algo/fcrfmc.py
@@ -1,0 +1,90 @@
+# Copyright 2022 The EvoJAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This is a wrapper of the CR-FM-NES algorithm.
+    See https://github.com/dietmarwo/fast-cma-es/blob/master/_fcmaescpp/crfmnes.cpp .
+    Eigen based implementation of Fast Moving Natural Evolution Strategy 
+    for High-Dimensional Problems (CR-FM-NES), see https://arxiv.org/abs/2201.11422 .
+    Derived from https://github.com/nomuramasahir0/crfmnes .
+"""
+
+import sys
+
+import logging
+import numpy as np
+import math
+from typing import Union
+
+import jax
+import jax.numpy as jnp
+
+from evojax.algo.base import NEAlgorithm
+from evojax.util import create_logger
+
+class FCRFMC(NEAlgorithm):
+    """A wrapper of CR-FM-NES Eigen version."""
+
+    def __init__(self,
+                 param_size: int,
+                 pop_size: int,
+                 init_stdev: float = 0.1,
+                 seed: int = 0,
+                 logger: logging.Logger = None):
+        if logger is None:
+            self.logger = create_logger(name='FCRFMC')
+        else:
+            self.logger = logger
+        self.pop_size = pop_size
+
+        try:
+            from scipy.optimize import Bounds
+            from fcmaes import crfmnescpp
+
+        except ModuleNotFoundError:
+            print("You need to install fcmaes:")
+            print("  pip install fcmaes --upgrade")
+            sys.exit(1)
+                 
+        self.fcrfm = crfmnescpp.CRFMNES_C(param_size, None, [0.]*param_size,
+                init_stdev, pop_size)    
+
+        self.params = None
+        self._best_params = None
+        self.maxy = -math.inf
+        
+        self.jnp_array = jax.jit(jnp.array)
+        self.jnp_stack = jax.jit(jnp.stack)
+        
+    def ask(self) -> jnp.ndarray:
+        self.params = self.fcrfm.ask()
+        return self.jnp_stack(self.params)
+
+    def tell(self, fitness: Union[np.ndarray, jnp.ndarray]) -> None:
+        y = np.array(fitness)
+        self.fcrfm.tell(-y)#, self.params)
+
+        maxy = np.max(y)
+        if self.maxy < maxy:
+            self.maxy = maxy
+            xi = np.argsort(y)        
+            self._best_params = self.params[xi[0]]
+
+    @property
+    def best_params(self) -> jnp.ndarray:
+        return self.jnp_array(self._best_params)
+
+    @best_params.setter
+    def best_params(self, params: Union[np.ndarray, jnp.ndarray]) -> None:
+        self._best_params = np.array(params)
+        self.cma.x0 = self._best_params.copy()

--- a/scripts/benchmarks/configs/FCRFMC/brax_ant.yaml
+++ b/scripts/benchmarks/configs/FCRFMC/brax_ant.yaml
@@ -3,11 +3,11 @@ problem_type: "brax"
 env_name: "ant"
 normalize: true
 es_config:
-  pop_size: 256
-  init_stdev: 0.1
+  pop_size: 64
+  init_stdev: 0.05
 num_tests: 128
 n_repeats: 16
-max_iter: 600
+max_iter: 2000
 test_interval: 100
 log_interval: 20
 seed: 42

--- a/scripts/benchmarks/configs/FCRFMC/brax_ant.yaml
+++ b/scripts/benchmarks/configs/FCRFMC/brax_ant.yaml
@@ -1,0 +1,15 @@
+es_name: "FCRFMC"
+problem_type: "brax"
+env_name: "ant"
+normalize: true
+es_config:
+  pop_size: 256
+  init_stdev: 0.1
+num_tests: 128
+n_repeats: 16
+max_iter: 600
+test_interval: 100
+log_interval: 20
+seed: 42
+gpu_id: [0, 1, 2, 3]
+debug: false

--- a/scripts/benchmarks/configs/FCRFMC/cartpole_easy.yaml
+++ b/scripts/benchmarks/configs/FCRFMC/cartpole_easy.yaml
@@ -2,7 +2,7 @@ es_name: "FCRFMC"
 problem_type: "cartpole_easy"
 normalize: false
 es_config:
-  pop_size: 48
+  pop_size: 64
   init_stdev: 0.3
 hidden_size: 64
 num_tests: 100

--- a/scripts/benchmarks/configs/FCRFMC/cartpole_easy.yaml
+++ b/scripts/benchmarks/configs/FCRFMC/cartpole_easy.yaml
@@ -1,0 +1,15 @@
+es_name: "FCRFMC"
+problem_type: "cartpole_easy"
+normalize: false
+es_config:
+  pop_size: 48
+  init_stdev: 0.3
+hidden_size: 64
+num_tests: 100
+n_repeats: 16
+max_iter: 1000
+test_interval: 100
+log_interval: 50
+seed: 42
+gpu_id: 0
+debug: false

--- a/scripts/benchmarks/configs/FCRFMC/cartpole_hard.yaml
+++ b/scripts/benchmarks/configs/FCRFMC/cartpole_hard.yaml
@@ -1,0 +1,15 @@
+es_name: "FCRFMC"
+problem_type: "cartpole_hard"
+normalize: false
+es_config:
+  pop_size: 48
+  init_stdev: 0.3
+hidden_size: 64
+num_tests: 100
+n_repeats: 16
+max_iter: 1500
+test_interval: 100
+log_interval: 50
+seed: 42
+gpu_id: 0
+debug: false

--- a/scripts/benchmarks/configs/FCRFMC/cartpole_hard.yaml
+++ b/scripts/benchmarks/configs/FCRFMC/cartpole_hard.yaml
@@ -2,12 +2,12 @@ es_name: "FCRFMC"
 problem_type: "cartpole_hard"
 normalize: false
 es_config:
-  pop_size: 48
+  pop_size: 64
   init_stdev: 0.3
 hidden_size: 64
 num_tests: 100
 n_repeats: 16
-max_iter: 1500
+max_iter: 1000
 test_interval: 100
 log_interval: 50
 seed: 42

--- a/scripts/benchmarks/configs/FCRFMC/mnist.yaml
+++ b/scripts/benchmarks/configs/FCRFMC/mnist.yaml
@@ -2,7 +2,7 @@ es_name: "FCRFMC"
 problem_type: "mnist"
 normalize: false
 es_config:
-  pop_size: 96
+  pop_size: 64
   init_stdev: 0.05
 hidden_size: 100
 batch_size: 1024

--- a/scripts/benchmarks/configs/FCRFMC/mnist.yaml
+++ b/scripts/benchmarks/configs/FCRFMC/mnist.yaml
@@ -1,0 +1,16 @@
+es_name: "FCRFMC"
+problem_type: "mnist"
+normalize: false
+es_config:
+  pop_size: 96
+  init_stdev: 0.05
+hidden_size: 100
+batch_size: 1024
+max_iter: 2000
+test_interval: 500
+log_interval: 100
+num_tests: 1
+n_repeats: 1
+seed: 42
+gpu_id: [0, 1, 2, 3]
+debug: false

--- a/scripts/benchmarks/configs/FCRFMC/waterworld.yaml
+++ b/scripts/benchmarks/configs/FCRFMC/waterworld.yaml
@@ -1,0 +1,15 @@
+es_name: "FCRFMC"
+problem_type: "waterworld"
+normalize: false
+es_config:
+  pop_size: 192
+  init_stdev: 0.05
+hidden_size: 100
+num_tests: 100
+n_repeats: 32
+max_iter: 1500
+test_interval: 50
+log_interval: 10
+seed: 42
+gpu_id: [0, 1, 2, 3]
+debug: false

--- a/scripts/benchmarks/configs/FCRFMC/waterworld_ma.yaml
+++ b/scripts/benchmarks/configs/FCRFMC/waterworld_ma.yaml
@@ -3,7 +3,7 @@ problem_type: "waterworld_ma"
 normalize: false
 es_config:
   pop_size: 16
-  init_stdev: 0.2
+  init_stdev: 0.12
 hidden_size: 100
 num_tests: 16
 n_repeats: 64

--- a/scripts/benchmarks/configs/FCRFMC/waterworld_ma.yaml
+++ b/scripts/benchmarks/configs/FCRFMC/waterworld_ma.yaml
@@ -1,0 +1,15 @@
+es_name: "FCRFMC"
+problem_type: "waterworld_ma"
+normalize: false
+es_config:
+  pop_size: 16
+  init_stdev: 0.2
+hidden_size: 100
+num_tests: 16
+n_repeats: 64
+max_iter: 2000
+test_interval: 100
+log_interval: 10
+seed: 42
+gpu_id: 0
+debug: false


### PR DESCRIPTION
Adds a wrapper to CR-FM-NES, see "Fast Moving Natural Evolution Strategy for High-Dimensional Problems (CR-FM-NES)" [pdf]( https://arxiv.org/abs/2201.11422) .

It wraps the [fcmaes](https://github.com/dietmarwo/fast-cma-es)  Eigen/C++ version of CR-FM-NES which is derived from https://github.com/nomuramasahir0/crfmnes. 

Since there are numpy and Eigen based implementations (and soon a JAX based one) of CR-FM-NES available, it will be possible to compare the performance of these tree "backends" for the same algorithm. 
This commit wraps only the C++/Eigen based implementation [crfmnes.cpp](https://github.com/dietmarwo/fast-cma-es/blob/master/_fcmaescpp/crfmnes.cpp) .

Tested on NVIDIA 3090 + AMD 5950x Linux Mint 20 (Ubuntu based). Performance (wall time) is similar 
to PGPE outperforming CMA_ES_JAX. Benchmark results for waterworld are above all other algorithms.
Do "pip install fcmaes --upgrade" before testing. 
 
