### PR TITLE
Native implementation in JAX of Augmented Random Search 

### DIFF
--- a/evojax/algo/__init__.py
+++ b/evojax/algo/__init__.py
@@ -25,6 +25,7 @@ from .cma_jax import CMA_ES_JAX
 from .map_elites import MAPElites
 from .iamalgam import iAMaLGaM
 from .fcrfmc import FCRFMC
+from .ars_native import ARS_native
 
 Strategies = {
     "CMA": CMA,
@@ -37,7 +38,8 @@ Strategies = {
     "CMA_ES_JAX": CMA_ES_JAX,
     "MAPElites": MAPElites,
     "iAMaLGaM": iAMaLGaM,
-    "FCRFMC": FCRFMC,
+    "FCRFMC": FCRFMC,    
+    "ARS_native": ARS_native,
 }
 
 __all__ = [
@@ -55,4 +57,5 @@ __all__ = [
     "iAMaLGaM",
     "FCRFMC",
     "Strategies",
+    "ARS_native"
 ]

--- a/evojax/algo/ars_native.py
+++ b/evojax/algo/ars_native.py
@@ -3,7 +3,10 @@ import jax.numpy as jnp
 import numpy as np
 from evojax.algo.base import NEAlgorithm
 from typing import Union
-from jax.example_libraries import optimizers
+try:
+    from jax.example_libraries import optimizers
+except ModuleNotFoundError:
+    from jax.experimental import optimizers
 import logging
 from evojax.util import create_logger
 

--- a/evojax/algo/ars_native.py
+++ b/evojax/algo/ars_native.py
@@ -1,0 +1,121 @@
+import jax
+import jax.numpy as jnp
+import numpy as np
+from evojax.algo.base import NEAlgorithm
+from typing import Union
+from jax.example_libraries import optimizers
+import logging
+from evojax.util import create_logger
+
+
+def get_optim(opt, optimizer_config, init_params):
+	''' convenience function for creating optimizer functions from configs '''
+	lrate_init = optimizer_config.get('lrate_init', 1e-3) 
+	lrate_limit = optimizer_config.get('lrate_limit', 1e-6)
+	decay_coef = optimizer_config.get('decay_coef', 1)
+	step_size=lambda x: jnp.maximum(lrate_init * jnp.power(decay_coef, x), lrate_limit)
+
+	if opt == 'sgd':
+		opt_init, opt_update, get_params = optimizers.sgd(
+			step_size=step_size,
+		)
+	elif opt == 'adam':
+		opt_init, opt_update, get_params = optimizers.adam(
+			step_size=step_size,
+			b1=optimizer_config.get("beta1", 0.9),
+			b2=optimizer_config.get("beta2", 0.999),
+			eps=optimizer_config.get("epsilon", 1e-8),
+		)
+	else:
+		raise Exception("optimizer not supported. Choose between sgd and adam")
+	opt_state = jax.jit(opt_init)(init_params)
+	opt_update = jax.jit(opt_update)
+	get_params = jax.jit(get_params)
+
+	return opt_state, opt_update, get_params
+
+
+
+class ARS_native(NEAlgorithm):
+	''' Augmented Random Search 
+	    Mania et al. (2018) https://arxiv.org/pdf/1803.07055.pdf'''
+	
+	def __init__(
+		self, 
+		param_size, 
+		pop_size, 
+		elite_ratio, 
+		decay_stdev=0.999, 
+		limit_stdev=0.01, 
+		init_stdev=0.03, 
+		seed=0, 
+		version=1,
+		optimizer='sgd',
+		optimizer_config={},
+		logger: logging.Logger = None
+	):
+		if logger is None:
+			self.logger = create_logger(name="ARS_native")
+		else:
+			self.logger = logger
+
+		assert pop_size % 2 == 0   # total perturbations considering positive and negative directions 
+		self.pop_size = pop_size
+		assert 0 < elite_ratio <= 1
+		self.elite_ratio = elite_ratio
+		self.elite_pop_size = int(self.pop_size / 2 * self.elite_ratio)
+		self.directions = pop_size // 2
+		self.params_population = None
+		self.param_size = param_size
+
+		self.noise = None
+		self.stdev = init_stdev 
+		self.rand_key, _key = jax.random.split(key=jax.random.PRNGKey(seed=seed), num=2)
+		init_min, init_max = 0, 0
+		self.mean_params = jax.random.uniform(_key, (param_size,), minval=init_min, maxval=init_max) 
+
+		self.version = version
+		self.decay_stdev = decay_stdev
+		self.limit_stdev = limit_stdev
+		self.opt_state, self.opt_update, self.opt_get_params = get_optim(optimizer, optimizer_config, self.mean_params)
+		self._t = 0
+
+		self.lr_decay_steps = optimizer_config.get('lr_decay_steps', 1)
+
+
+	def ask(self):
+		self.rand_key, _key = jax.random.split(key=self.rand_key, num=2)
+		self.noise = jax.random.normal(key=_key, shape=(self.directions, self.param_size))
+		perturbation = jnp.concatenate([self.noise, -self.noise], axis=0)
+
+		# evaluate each perturbation in both directions 
+		self.params_population = self.mean_params + self.stdev * perturbation
+		return self.params_population
+
+	def tell(self, fitness):
+		pos = fitness[:self.directions]
+		neg = fitness[self.directions:]
+
+		selected_dir_ids = jnp.minimum(pos, neg).argsort()[:self.elite_pop_size]
+		selected_fitness_stdev = jnp.std(
+			jnp.concatenate(
+				[pos[selected_dir_ids], neg[selected_dir_ids]]
+			)
+		) + 1e-05
+		fitness_diff = pos[selected_dir_ids]-neg[selected_dir_ids]
+		selected_noise = self.noise[selected_dir_ids]
+		update = 1 / (self.elite_pop_size*selected_fitness_stdev) * jnp.dot(selected_noise.T, fitness_diff) 
+
+		self.opt_state = self.opt_update(self._t // self.lr_decay_steps, -update, self.opt_state)
+		self._t += 1
+		self.mean_params = self.opt_get_params(self.opt_state)
+
+		self.stdev = jnp.maximum(self.stdev*self.decay_stdev, self.limit_stdev)
+
+	@property
+	def best_params(self) -> jnp.ndarray:	
+		return self.mean_params
+	
+	@best_params.setter
+	def best_params(self, params: Union[np.ndarray, jnp.ndarray]) -> None:
+		self.mean_params = params 

--- a/scripts/benchmarks/Readme.md
+++ b/scripts/benchmarks/Readme.md
@@ -150,3 +150,16 @@ MNIST	| 0.90 (max_iter=2000)	| [Link](configs/ARS/mnist.yaml)| 0.9610 |
 | Cartpole-Easy  | Cartpole-Hard | MNIST | 
 |---|---|---|
 <img src="figures/ARS/cartpole_easy.png?raw=true" alt="drawing" width="200" />|<img src="figures/ARS/cartpole_hard.png?raw=true" alt="drawing" width="200" />| <img src="figures/ARS/mnist.png?raw=true" alt="drawing" width="200" /> |
+
+
+
+### Augmented Random Search (jax native)
+
+|                          | Benchmark                   | Params   | Results (avg.) |
+| ----------------|-----------------------|----------|------------- |
+| CartPole (easy) | 900 (max_iter=1000)  | [Link](configs/ARS_native/cartpole_easy.yaml)| 910        |
+| CartPole (hard) | 600 (max_iter=2000)  | [Link](configs/ARS_native/cartpole_hard.yaml) | 558.02       |
+| MNIST | 0.90 (max_iter=4000)  | [Link](configs/ARS_native/minst.yaml) | 0.92       |
+| Brax Ant | 3000 (max_iter=700)  | [Link](configs/ARS_native/brax_ant.yaml) | 4129.83        |
+| Waterworld |  6 (max_iter=2000) |[Link](configs/ARS_native/waterworld.yaml) | 7.29 | 
+| Waterworld (MA) |  2 (max_iter=2000) | [Link](configs/ARS_native/waterworld_ma.yaml) | 1.68 | 

--- a/scripts/benchmarks/configs/ARS_native/brax_ant.yaml
+++ b/scripts/benchmarks/configs/ARS_native/brax_ant.yaml
@@ -1,0 +1,27 @@
+es_name: "ARS_native"
+problem_type: "brax"
+env_name: "ant"
+normalize: true
+es_config:
+  pop_size: 1024
+  elite_ratio: 0.05
+  init_stdev: 0.05
+  decay_stdev: 0.999
+  limit_stdev: 0.001
+  optimizer: "adam"
+  optimizer_config:
+    lrate_init: 0.01
+    lrate_decay: 0.999
+    lrate_limit: 0.001
+    beta_1: 0.99
+    beta_2: 0.999
+    eps: 1e-08
+num_tests: 128
+n_repeats: 16
+max_iter: 700
+test_interval: 100
+log_interval: 20
+seed: 42  
+gpu_id: 0
+debug: false
+

--- a/scripts/benchmarks/configs/ARS_native/cartpole_easy.yaml
+++ b/scripts/benchmarks/configs/ARS_native/cartpole_easy.yaml
@@ -1,0 +1,24 @@
+es_name: "ARS_native"
+problem_type: "cartpole_easy"
+normalize: false
+es_config:
+  pop_size: 100
+  elite_ratio: 0.1
+  init_stdev: 0.1
+  decay_stdev: 0.999
+  limit_stdev: 0.01
+  optimizer: "sgd"
+  optimizer_config:
+    lrate_init: 0.05
+    lrate_decay_steps: 1
+    lrate_limit: 1e-3
+    decay_coef: 1
+hidden_size: 64
+num_tests: 100
+n_repeats: 16
+max_iter: 1000
+test_interval: 100
+log_interval: 50
+seed: 42
+gpu_id: 0
+debug: true

--- a/scripts/benchmarks/configs/ARS_native/cartpole_hard.yaml
+++ b/scripts/benchmarks/configs/ARS_native/cartpole_hard.yaml
@@ -1,0 +1,26 @@
+
+es_name: "ARS_native"
+problem_type: "cartpole_hard"
+normalize: false
+es_config:
+  pop_size: 100
+  elite_ratio: 0.1
+  init_stdev: 0.1
+  decay_stdev: 0.999
+  limit_stdev: 0.01
+  optimizer: "sgd"
+  optimizer_config:
+    lrate_init: 0.075
+    lrate_decay_steps: 1
+    lrate_limit: 0.001
+    decay_coef: 1
+hidden_size: 64
+hidden_size: 64
+num_tests: 100
+n_repeats: 16
+max_iter: 2000
+test_interval: 100
+log_interval: 20
+seed: 42
+gpu_id: 0
+debug: false

--- a/scripts/benchmarks/configs/ARS_native/mnist.yaml
+++ b/scripts/benchmarks/configs/ARS_native/mnist.yaml
@@ -1,0 +1,25 @@
+es_name: "ARS_native"
+problem_type: "mnist"
+normalize: false
+es_config:
+  elite_ratio: 0.1
+  pop_size: 100
+  init_stdev: 0.03
+  decay_stdev: 0.999
+  limit_stdev: 0.01
+  optimizer: "sgd"
+  optimizer_config:
+    lrate_init: 0.01
+    lrate_decay: 0.999
+    lrate_limit: 0.001
+    momentum: 0.0
+hidden_size: 100
+batch_size: 512
+max_iter: 4000
+test_interval: 500
+log_interval: 100
+num_tests: 1
+n_repeats: 1
+seed: 42
+gpu_id: [0]
+debug: false

--- a/scripts/benchmarks/configs/ARS_native/search.yaml
+++ b/scripts/benchmarks/configs/ARS_native/search.yaml
@@ -1,0 +1,14 @@
+num_iters: 25
+search_type: "Grid"
+maximize_objective: true
+verbose: true
+search_params:
+  real:
+    es_config/optimizer_config/lrate_init:
+      begin: 0.001
+      end: 0.1
+      bins: 5
+    es_config/init_stdev:
+      begin: 0.01
+      end: 0.1
+      bins: 5

--- a/scripts/benchmarks/configs/ARS_native/waterworld.yaml
+++ b/scripts/benchmarks/configs/ARS_native/waterworld.yaml
@@ -1,0 +1,24 @@
+
+es_name: "ARS_native"
+problem_type: "waterworld"
+normalize: false 
+es_config:
+  pop_size: 256
+  elite_ratio: 0.1
+  init_stdev: 0.05
+  decay_stdev: 0.999
+  limit_stdev: 0.001
+  optimizer: "sgd"
+  optimizer_config: 
+    lrate_init: 0.01
+    lrate_limit: 0.01
+    decay_coef: 1
+hidden_size: 100
+num_tests: 100
+n_repeats: 32
+max_iter: 2000
+test_interval: 50
+log_interval: 10
+seed: 42
+gpu_id: 0
+debug: false

--- a/scripts/benchmarks/configs/ARS_native/waterworld_ma.yaml
+++ b/scripts/benchmarks/configs/ARS_native/waterworld_ma.yaml
@@ -1,0 +1,23 @@
+es_name: "ARS_native"
+problem_type: "waterworld_ma"
+normalize: false
+es_config:
+  elite_ratio: 0.5
+  pop_size: 16
+  init_stdev: 0.1
+  decay_stdev: 0.999
+  limit_stdev: 0.001
+  optimizer: "sgd"
+  optimizer_config: 
+    lrate_init: 0.01
+    lrate_limit: 0.01
+    decay_coef: 1
+hidden_size: 100
+num_tests: 16
+n_repeats: 64
+max_iter: 2000
+test_interval: 100
+log_interval: 10
+seed: 42
+gpu_id: 0
+debug: false


### PR DESCRIPTION
## Test results 
**Note** for MNIST I halved the batch size and doubled the iterations due to memory issues. 
|                          | Benchmark                   | Params   | Results (avg.) |
| ----------------|-----------------------|----------|------------- |
| CartPole (easy) | 900 (max_iter=1000)  | [Link](configs/ARS_native/cartpole_easy.yaml)| 910        |
| CartPole (hard) | 600 (max_iter=2000)  | [Link](configs/ARS_native/cartpole_hard.yaml) | 558.02       |
| MNIST | 0.90 (max_iter=4000)  | [Link](configs/ARS_native/minst.yaml) | 0.92       |
| Brax Ant | 3000 (max_iter=700)  | [Link](configs/ARS_native/brax_ant.yaml) | 4129.83        |
| Waterworld |  6 (max_iter=2000) |[Link](configs/ARS_native/waterworld.yaml) | 7.29 | 
| Waterworld (MA) |  2 (max_iter=2000) | [Link](configs/ARS_native/waterworld_ma.yaml) | 1.68 | 
