### PR TITLE
Fix brax env create compatibility issue

### DIFF
--- a/evojax/task/brax_task.py
+++ b/evojax/task/brax_task.py
@@ -61,7 +61,6 @@ class BraxTask(VectorizedTask):
     def __init__(self,
                  env_name: str,
                  max_steps: int = 1000,
-                 legacy_spring: bool = True,
                  bd_extractor: Optional[BDExtractor] = None,
                  test: bool = False):
         self.max_steps = max_steps

--- a/evojax/task/brax_task.py
+++ b/evojax/task/brax_task.py
@@ -69,8 +69,7 @@ class BraxTask(VectorizedTask):
         self.test = test
         brax_env = create(
             env_name=env_name,
-            episode_length=max_steps,
-            legacy_spring=legacy_spring,
+            episode_length=max_steps
         )
         self.obs_shape = tuple([brax_env.observation_size, ])
         self.act_shape = tuple([brax_env.action_size, ])


### PR DESCRIPTION
Updated `brax_task.py` to reflect changes in underlying Brax simulator (`brax.envs.create` does not take `legacy_spring` argument anymore).