### PR TITLE
Pin pip install in example notebook to fix version rot

### DIFF
--- a/examples/notebooks/LeniaEvoJAX.ipynb
+++ b/examples/notebooks/LeniaEvoJAX.ipynb
@@ -60,7 +60,7 @@
       ],
       "source": [
         "#@title Import\n",
-        "!pip install evojax\n",
+        "!pip install jax==0.4.6 evojax==0.2.15 jaxlib==0.4.6\n",
         "import google.colab\n",
         "google.colab.output.clear()\n",
         "\n",


### PR DESCRIPTION
With package versions as installed in 2025, an error about `maps` being unavailable in `jax.experimental` occurs.